### PR TITLE
Improve dependency searching (FMI Library & libzip) when find_package(Coral) is used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,7 @@ install (DIRECTORY "${CMAKE_SOURCE_DIR}/manuals/" DESTINATION ${docInstallDir})
 install (FILES
         "cmake/FindBoostTarget.cmake"
         "cmake/FindFMILIB.cmake"
+        "cmake/FindLIBZIP.cmake"
         "cmake/FindProtobufTarget.cmake"
         "cmake/FindZMQ.cmake"
     DESTINATION

--- a/cmake/FindFMILIB.cmake
+++ b/cmake/FindFMILIB.cmake
@@ -32,7 +32,12 @@ cmake_minimum_required (VERSION 2.8.11)
 
 # Find static library, and use its path prefix to provide a HINTS option to the
 # other find_*() commands.
-find_library (FMILIB_LIBRARY "fmilib"
+if (UNIX)
+    set (_FMILIB_oldsuffixes ${CMAKE_FIND_LIBRARY_SUFFIXES})
+    set (CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+endif ()
+find_library (FMILIB_LIBRARY
+    NAMES "fmilib2" "fmilib"
     PATHS ${FMILIB_DIR} $ENV{FMILIB_DIR}
     PATH_SUFFIXES "lib")
 mark_as_advanced (FMILIB_LIBRARY)
@@ -45,7 +50,11 @@ if (FMILIB_LIBRARY)
 endif ()
 
 # Find shared/import library and append its path prefix to the HINTS option.
-find_library (FMILIB_SHARED_LIBRARY "fmilib_shared"
+if (UNIX)
+    set (CMAKE_FIND_LIBRARY_SUFFIXES ".so")
+endif ()
+find_library (FMILIB_SHARED_LIBRARY
+    NAMES "fmilib2" "fmilib"
     ${_FMILIB_hints}
     PATHS ${FMILIB_DIR} $ENV{FMILIB_DIR}
     PATH_SUFFIXES "lib")
@@ -58,6 +67,12 @@ if (FMILIB_SHARED_LIBRARY)
     endif ()
     list (APPEND _FMILIB_hints "${_FMILIB_shared_prefix}")
     unset (_FMILIB_shared_prefix)
+endif ()
+
+# Reset CMAKE_FIND_LIBRARY_SUFFIXES
+if (UNIX)
+    set (CMAKE_FIND_LIBRARY_SUFFIXES ${_FMILIB_oldsuffixes})
+    unset (_FMILIB_oldsuffixes)
 endif ()
 
 # Find header files and, on Windows, the dynamic library

--- a/cmake/project-config.cmake.in
+++ b/cmake/project-config.cmake.in
@@ -5,6 +5,7 @@ find_package (BoostTarget REQUIRED COMPONENTS filesystem thread system chrono ra
 find_package (ZMQ REQUIRED)
 find_package (ProtobufTarget REQUIRED)
 find_package (FMILIB REQUIRED)
+find_package (LIBZIP REQUIRED)
 set (CMAKE_MODULE_PATH ${_old_CMAKE_MODULE_PATH})
 unset (_old_CMAKE_MODULE_PATH)
 


### PR DESCRIPTION
This is necessary for client code which uses Coral as a library, and which uses CMake's `find_package()` command to locate it.  This ensures that `find_package(Coral)` also locates libzip together with the other dependencies.