### PR TITLE
Move coral::util::TempDir to the public API

### DIFF
--- a/include/coral/fmi/importer.hpp
+++ b/include/coral/fmi/importer.hpp
@@ -14,10 +14,10 @@
 #include <memory>
 #include <string>
 
-#include "boost/filesystem/path.hpp"
+#include <boost/filesystem.hpp>
 
-#include "coral/config.h"
-#include "coral/util.hpp"
+#include <coral/config.h>
+#include <coral/util/filesystem.hpp>
 
 
 // Forward declarations to avoid external dependency on FMI Library.

--- a/include/coral/util/filesystem.hpp
+++ b/include/coral/util/filesystem.hpp
@@ -1,0 +1,77 @@
+/**
+ *  \file
+ *  \brief Filesystem utilities.
+ *  \copyright
+ *      Copyright 2013-2017, SINTEF Ocean and the Coral contributors.
+ *      This Source Code Form is subject to the terms of the Mozilla Public
+ *      License, v. 2.0. If a copy of the MPL was not distributed with this
+ *      file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#ifndef CORAL_UTIL_FILESYSTEM_HPP
+#define CORAL_UTIL_FILESYSTEM_HPP
+
+#include <boost/filesystem.hpp>
+#include <coral/config.h>
+
+
+namespace coral
+{
+namespace util
+{
+
+
+/**
+ *  \brief  An RAII object that creates a unique directory on construction
+ *          and recursively deletes it again on destruction.
+*/
+class TempDir
+{
+public:
+    /**
+     *  \brief  Creates a new temporary directory.
+     *
+     *  The name of the new directory will be randomly generated, and there are
+     *  three options of where it will be created, depending on the value of
+     *  `parent`.  In the following, `temp` refers to a directory suitable for
+     *  temporary files under the conventions of the operating system (e.g.
+     *  `/tmp` under UNIX-like systems), and `name` refers to the randomly
+     *  generated name mentioned above.
+     *
+     *    - If `parent` is empty: `temp/name`
+     *    - If `parent` is relative: `temp/parent/name`
+     *    - If `parent` is absolute: `parent/name`
+    */
+    explicit TempDir(
+        const boost::filesystem::path& parent = boost::filesystem::path());
+
+    TempDir(const TempDir&) = delete;
+    TempDir& operator=(const TempDir&) = delete;
+
+    /**
+     *  \brief  Move constructor.
+     *
+     *  Ownership of the directory is transferred from `other` to `this`.
+     *  Afterwards, `other` no longer refers to any directory, meaning that
+     *  `other.Path()` will return an empty path, and its destructor will not
+     *  perform any filesystem operations.
+    */
+    TempDir(TempDir&& other) CORAL_NOEXCEPT;
+
+    /// Move assignment operator. See TempDir(TempDir&&) for semantics.
+    TempDir& operator=(TempDir&&) CORAL_NOEXCEPT;
+
+    /// Destructor.  Recursively deletes the directory.
+    ~TempDir() CORAL_NOEXCEPT;
+
+    /// Returns the path to the directory.
+    const boost::filesystem::path& Path() const;
+
+private:
+    void DeleteNoexcept() CORAL_NOEXCEPT;
+
+    boost::filesystem::path m_path;
+};
+
+
+}} // namespace
+#endif // header guard

--- a/src/include/coral/util.hpp
+++ b/src/include/coral/util.hpp
@@ -190,59 +190,6 @@ ScopeGuard<Action> OnScopeExit(Action action) { return ScopeGuard<Action>(action
 
 
 /**
-\brief  An RAII object that creates a unique directory on construction
-        and recursively deletes it again on destruction.
-*/
-class TempDir
-{
-public:
-    /**
-    \brief  Creates a new temporary directory.
-
-    The name of the new directory will be randomly generated, and there are
-    three options of where it will be created, depending on the value of
-    `parent`.  In the following, `temp` refers to a directory suitable for
-    temporary files under the conventions of the operating system (e.g. `/tmp`
-    under UNIX-like systems), and `name` refers to the randomly generated
-    name mentioned above.
-
-      - If `parent` is empty: `temp/name`
-      - If `parent` is relative: `temp/parent/name`
-      - If `parent` is absolute: `parent/name`
-    */
-    explicit TempDir(
-        const boost::filesystem::path& parent = boost::filesystem::path());
-
-    TempDir(const TempDir&) = delete;
-    TempDir& operator=(const TempDir&) = delete;
-
-    /**
-    \brief  Move constructor.
-
-    Ownership of the directory is transferred from `other` to `this`.
-    Afterwards, `other` no longer refers to any directory, meaning that
-    `other.Path()` will return an empty path, and its destructor will not
-    perform any filesystem operations.
-    */
-    TempDir(TempDir&& other) CORAL_NOEXCEPT;
-
-    /// Move assignment operator. See TempDir(TempDir&&) for semantics.
-    TempDir& operator=(TempDir&&) CORAL_NOEXCEPT;
-
-    /// Destructor.  Recursively deletes the directory.
-    ~TempDir() CORAL_NOEXCEPT;
-
-    /// Returns the path to the directory.
-    const boost::filesystem::path& Path() const;
-
-private:
-    void DeleteNoexcept() CORAL_NOEXCEPT;
-
-    boost::filesystem::path m_path;
-};
-
-
-/**
 \brief  Starts a new process.
 
 Windows warning: This function only supports a very limited form of argument

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -22,6 +22,7 @@ set (_publicHeaders
     "coral/slave/instance.hpp"
     "coral/slave/logging.hpp"
     "coral/slave/runner.hpp"
+    "coral/util/filesystem.hpp"
 )
 set (_privateHeaders
     "coral/async.hpp"
@@ -63,6 +64,7 @@ set (_sources
     "slave_logging.cpp"
     "slave_runner.cpp"
     "net.cpp"
+    "util_filesystem.cpp"
 
     "async.cpp"
     "bus_execution_manager.cpp"
@@ -112,6 +114,7 @@ set (_testSources
     "protocol_execution_test.cpp"
     "util_test.cpp"
     "util_console_test.cpp"
+    "util_filesystem_test.cpp"
     "util_zip_test.cpp"
 )
 

--- a/src/lib/util.cpp
+++ b/src/lib/util.cpp
@@ -134,56 +134,6 @@ std::string coral::util::Timestamp()
 }
 
 
-coral::util::TempDir::TempDir(const boost::filesystem::path& parent)
-{
-    if (parent.empty()) {
-        m_path = boost::filesystem::temp_directory_path()
-            / boost::filesystem::unique_path();
-    } else if (parent.is_absolute()) {
-        m_path = parent / boost::filesystem::unique_path();
-    } else {
-        m_path = boost::filesystem::temp_directory_path()
-            / parent / boost::filesystem::unique_path();
-    }
-    boost::filesystem::create_directories(m_path);
-}
-
-coral::util::TempDir::TempDir(TempDir&& other) CORAL_NOEXCEPT
-    : m_path{std::move(other.m_path)}
-{
-    // This doesn't seem to be guaranteed by path's move constructor:
-    other.m_path.clear();
-}
-
-coral::util::TempDir& coral::util::TempDir::operator=(TempDir&& other) CORAL_NOEXCEPT
-{
-    DeleteNoexcept();
-    m_path = std::move(other.m_path);
-    // This doesn't seem to be guaranteed by path's move constructor:
-    other.m_path.clear();
-    return *this;
-}
-
-coral::util::TempDir::~TempDir()
-{
-    DeleteNoexcept();
-}
-
-const boost::filesystem::path& coral::util::TempDir::Path() const
-{
-    return m_path;
-}
-
-void coral::util::TempDir::DeleteNoexcept() CORAL_NOEXCEPT
-{
-    if (!m_path.empty()) {
-        boost::system::error_code ignoreErrors;
-        boost::filesystem::remove_all(m_path, ignoreErrors);
-        m_path.clear();
-    }
-}
-
-
 #ifdef _WIN32
 namespace
 {

--- a/src/lib/util_filesystem.cpp
+++ b/src/lib/util_filesystem.cpp
@@ -1,0 +1,69 @@
+/*
+Copyright 2013-2017, SINTEF Ocean and the Coral contributors.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+#include "coral/util/filesystem.hpp"
+
+#include <utility>
+#include <boost/filesystem.hpp>
+
+
+namespace coral
+{
+namespace util
+{
+
+
+coral::util::TempDir::TempDir(const boost::filesystem::path& parent)
+{
+    if (parent.empty()) {
+        m_path = boost::filesystem::temp_directory_path()
+            / boost::filesystem::unique_path();
+    } else if (parent.is_absolute()) {
+        m_path = parent / boost::filesystem::unique_path();
+    } else {
+        m_path = boost::filesystem::temp_directory_path()
+            / parent / boost::filesystem::unique_path();
+    }
+    boost::filesystem::create_directories(m_path);
+}
+
+coral::util::TempDir::TempDir(TempDir&& other) CORAL_NOEXCEPT
+    : m_path{std::move(other.m_path)}
+{
+    // This doesn't seem to be guaranteed by path's move constructor:
+    other.m_path.clear();
+}
+
+coral::util::TempDir& coral::util::TempDir::operator=(TempDir&& other) CORAL_NOEXCEPT
+{
+    DeleteNoexcept();
+    m_path = std::move(other.m_path);
+    // This doesn't seem to be guaranteed by path's move constructor:
+    other.m_path.clear();
+    return *this;
+}
+
+coral::util::TempDir::~TempDir()
+{
+    DeleteNoexcept();
+}
+
+const boost::filesystem::path& coral::util::TempDir::Path() const
+{
+    return m_path;
+}
+
+void coral::util::TempDir::DeleteNoexcept() CORAL_NOEXCEPT
+{
+    if (!m_path.empty()) {
+        boost::system::error_code ignoreErrors;
+        boost::filesystem::remove_all(m_path, ignoreErrors);
+        m_path.clear();
+    }
+}
+
+
+}} // namespace

--- a/src/lib/util_filesystem_test.cpp
+++ b/src/lib/util_filesystem_test.cpp
@@ -1,0 +1,36 @@
+#include <utility>
+#include <boost/filesystem.hpp>
+#include <gtest/gtest.h>
+#include <coral/util/filesystem.hpp>
+
+
+TEST(coral_util_filesystem, TempDir)
+{
+    namespace fs = boost::filesystem;
+    fs::path d;
+    {
+        auto tmp = coral::util::TempDir();
+        d = tmp.Path();
+        ASSERT_FALSE(d.empty());
+        ASSERT_TRUE(fs::exists(d));
+        EXPECT_TRUE(fs::is_directory(d));
+        EXPECT_TRUE(fs::is_empty(d));
+
+        auto tmp2 = std::move(tmp);
+        EXPECT_TRUE(tmp.Path().empty());
+        EXPECT_EQ(d, tmp2.Path());
+        EXPECT_TRUE(fs::exists(d));
+
+        auto tmp3 = coral::util::TempDir();
+        const auto d3 = tmp3.Path();
+        EXPECT_TRUE(fs::exists(d3));
+        ASSERT_FALSE(fs::equivalent(d, d3));
+
+        tmp3 = std::move(tmp2);
+        EXPECT_TRUE(tmp2.Path().empty());
+        EXPECT_FALSE(fs::exists(d3));
+        EXPECT_EQ(d, tmp3.Path());
+        EXPECT_TRUE(fs::exists(d));
+    }
+    EXPECT_FALSE(fs::exists(d));
+}

--- a/src/lib/util_test.cpp
+++ b/src/lib/util_test.cpp
@@ -3,7 +3,6 @@
 #include <functional>
 #include <stdexcept>
 #include <vector>
-#include "boost/filesystem.hpp"
 
 
 using namespace coral::util;
@@ -201,37 +200,6 @@ TEST(coral_util, OnScopeExit)
         i = 3;
     }
     EXPECT_EQ(3, i);
-}
-
-TEST(coral_util, TempDir)
-{
-    namespace fs = boost::filesystem;
-    fs::path d;
-    {
-        auto tmp = TempDir();
-        d = tmp.Path();
-        ASSERT_FALSE(d.empty());
-        ASSERT_TRUE(fs::exists(d));
-        EXPECT_TRUE(fs::is_directory(d));
-        EXPECT_TRUE(fs::is_empty(d));
-
-        auto tmp2 = std::move(tmp);
-        EXPECT_TRUE(tmp.Path().empty());
-        EXPECT_EQ(d, tmp2.Path());
-        EXPECT_TRUE(fs::exists(d));
-
-        auto tmp3 = TempDir();
-        const auto d3 = tmp3.Path();
-        EXPECT_TRUE(fs::exists(d3));
-        ASSERT_FALSE(fs::equivalent(d, d3));
-
-        tmp3 = std::move(tmp2);
-        EXPECT_TRUE(tmp2.Path().empty());
-        EXPECT_FALSE(fs::exists(d3));
-        EXPECT_EQ(d, tmp3.Path());
-        EXPECT_TRUE(fs::exists(d));
-    }
-    EXPECT_FALSE(fs::exists(d));
 }
 
 TEST(coral_util, ThisExePath)

--- a/src/lib/util_zip_test.cpp
+++ b/src/lib/util_zip_test.cpp
@@ -1,11 +1,11 @@
 #include <cstdlib>
 #include <ios>
 
-#include "boost/filesystem.hpp"
-#include "gtest/gtest.h"
+#include <boost/filesystem.hpp>
+#include <gtest/gtest.h>
 
-#include "coral/util.hpp"
-#include "coral/util/zip.hpp"
+#include <coral/util/filesystem.hpp>
+#include <coral/util/zip.hpp>
 
 
 TEST(coral_util_zip, Archive)


### PR DESCRIPTION
This fixes issue #9. It is rather critical, because that issue makes Coral more or less unusable as a library.