### PR TITLE
Add option to pause after slave processes have started

### DIFF
--- a/src/master/config_parser.hpp
+++ b/src/master/config_parser.hpp
@@ -8,6 +8,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #define CORALMASTER_CONFIG_PARSER_HPP
 
 #include <chrono>
+#include <functional>
 #include <ostream>
 #include <stdexcept>
 #include <string>
@@ -50,7 +51,8 @@ void ParseSystemConfig(
     std::vector<SimulationEvent>& scenario,
     std::chrono::milliseconds commTimeout,
     std::chrono::milliseconds instantiationTimeout,
-    std::ostream* warningLog);
+    std::ostream* warningLog,
+    std::function<void()> postInstantiationHook);
 
 
 class SetVariablesException : public std::runtime_error


### PR DESCRIPTION
This fixes issue #15.  It is a somewhat ad-hoc solution, but coralmaster wasn't exactly a paragon of principled programming to begin with.

Now, coralmaster can be run with the switch `--debug-pause`. It will then wait for a user keypress *after* the slaves have been spawned, but *before* the master connects to them—that is, before any of the FMI functions have been called.