### PR TITLE
Allow infinite timeouts

### DIFF
--- a/include/coral/bus/variable_io.hpp
+++ b/include/coral/bus/variable_io.hpp
@@ -140,6 +140,7 @@ public:
     \param [in] stepID      The timestep ID for which we should wait for
                             variable data.
     \param [in] timeout     How long to wait without receiving any data.
+                            A negative value means to wait indefinitely.
 
     \returns Whether a value has been received for all variables.
     \pre Connect() has been called successfully on this instance.

--- a/include/coral/master/cluster.hpp
+++ b/include/coral/master/cluster.hpp
@@ -83,6 +83,7 @@ public:
 
     \param [in] timeout
         Maximum time to wait for replies from known slave providers.
+        A negative value means to wait indefinitely.
     */
     std::vector<SlaveType> GetSlaveTypes(std::chrono::milliseconds timeout);
 
@@ -92,9 +93,10 @@ public:
     `timeout` specifies how long the slave provider should wait for the
     slave to start up before assuming it has crashed or frozen.  The master
     will wait twice as long as this for the slave provider to report that the
-    slave has been successfully instantiated before it assumes the slave
+    slave has been successfully instantiated before it assumes that the slave
     provider itself has crashed or the connection has been lost.
-    In both cases, an exception is thrown.
+    In both cases, an exception is thrown.  A negative value means that there
+    is to be no time limit.
 
     \param [in] slaveProviderID
         The ID of the slave provider that should instantiate the slave.
@@ -102,7 +104,8 @@ public:
         The UUID that identifies the type of the slave that is to be
         instantiated.
     \param [in] timeout
-        How much time the slave gets to start up.
+        How much time the slave gets to start up. A negative value means
+        no limit.
 
     \returns
         An object that contains the information needed to locate the slave.

--- a/include/coral/master/execution.hpp
+++ b/include/coral/master/execution.hpp
@@ -167,7 +167,7 @@ public:
         Contains information about the slaves on output.
     \param [in] commTimeout
         The communications timeout used to detect loss of communication
-        with the slaves.
+        with the slaves.  A negative value means no timeout.
     */
     void Reconstitute(
         std::vector<AddedSlave>& slavesToAdd,
@@ -194,7 +194,7 @@ public:
         entry per slave.
     \param [in] commTimeout
         The communications timeout used to detect loss of communication
-        with the slaves.
+        with the slaves.  A negative value means no timeout.
     */
     void Reconfigure(
         std::vector<SlaveConfig>& slaveConfigs,
@@ -230,7 +230,7 @@ public:
         slave fails to report back within this time, it is considered a fatal
         error which will cause the entire simulation to shut down.
         (Essentially, it is assumed that we have lost connection with the slave
-        for some reason.) Must be a positive number.
+        for some reason.)  A negative value means no timeout.
     \param [in] slaveResults
         An optional vector which, if given, will be cleared and filled with
         the result reported by each slave.
@@ -256,7 +256,7 @@ public:
         slave fails to report back within this time, it is considered a fatal
         error which will cause the entire simulation to shut down.
         (Essentially, it is assumed that we have lost connection with the slave
-        for some reason.)
+        for some reason.)  A negative value means no timeout.
     */
     void AcceptStep(std::chrono::milliseconds timeout);
 

--- a/include/coral/master/execution_options.hpp
+++ b/include/coral/master/execution_options.hpp
@@ -42,6 +42,7 @@ struct ExecutionOptions
             other slaves.
 
     This is used when slaves exchange variable values among themselves.
+    A negative value effectively means no timeout.
     */
     std::chrono::milliseconds slaveVariableRecvTimeout = std::chrono::seconds(1);
 };

--- a/include/coral/provider/slave_creator.hpp
+++ b/include/coral/provider/slave_creator.hpp
@@ -58,7 +58,8 @@ public:
     \param [in] timeout
         How long the master will wait for the slave to start up.  If possible,
         instantiation should be aborted and considered "failed" after this
-        time has passed.
+        time has passed. A negative value means that there is no timeout,
+        the slave gets as much time as it needs.
     \param [out] slaveLocator
         An object that describes how to connect to the slave.  See the list
         above for different endpoint formats.

--- a/proto/domain.proto
+++ b/proto/domain.proto
@@ -22,6 +22,8 @@ message SlaveTypeList
 message InstantiateSlaveData
 {
     required string slave_type_uuid = 1;
+
+    // The special value -1 means "never"
     required int32 timeout_ms = 2;
 }
 

--- a/proto/execution.proto
+++ b/proto/execution.proto
@@ -70,7 +70,7 @@ message SetupData
     optional double stop_time = 3;
     optional string execution_name = 4;
     optional string slave_name = 5;
-    optional int32 variable_recv_timeout_ms = 6;
+    optional int32 variable_recv_timeout_ms = 6; // -1 = infinite
 }
 
 // A message that is sent by the master to a slave to set some of its variables.

--- a/src/include/coral/bus/execution_manager.hpp
+++ b/src/include/coral/bus/execution_manager.hpp
@@ -120,7 +120,7 @@ public:
         Contains information about the slaves on output.
     \param [in] commTimeout
         The communications timeout used to detect loss of communication
-        with the slaves.
+        with the slaves.  A negative value means no timeout.
     \param [in] onComplete
         Handler callback which is called when the entire operation is
         complete.
@@ -155,7 +155,7 @@ public:
         entry per slave.
     \param [in] commTimeout
         The communications timeout used to detect loss of communication
-        with the slaves.
+        with the slaves.  A negative value means no timeout.
     \param [in] onComplete
         Handler callback which is called when the entire operation is
         complete.

--- a/src/include/coral/bus/slave_control_messenger.hpp
+++ b/src/include/coral/bus/slave_control_messenger.hpp
@@ -214,7 +214,8 @@ public:
 
     All error conditions are fatal unless otherwise specified.
 
-    \param [in] timeout         Max. allowed time for the operation to complete
+    \param [in] timeout         Max. allowed time for the operation to complete.
+                                A negative value means no time limit.
     \param [in] onComplete      Completion handler
 
     \throws std::invalid_argument if `timeout` is less than 1 ms or
@@ -263,7 +264,8 @@ public:
         implemented yet.
 
     \param [in] settings        A list of variable values and connections
-    \param [in] timeout         Max. allowed time for the operation to complete
+    \param [in] timeout         Max. allowed time for the operation to complete.
+                                A negative value means no time limit.
     \param [in] onComplete      Completion handler
 
     \throws std::invalid_argument if `timeout` is less than 1 ms or
@@ -313,7 +315,8 @@ public:
         implemented yet.
 
     \param [in] peers           A list of peer endpoints
-    \param [in] timeout         Max. allowed time for the operation to complete
+    \param [in] timeout         Max. allowed time for the operation to complete.
+                                A negative value means no time limit.
     \param [in] onComplete      Completion handler
 
     \throws std::invalid_argument if `timeout` is less than 1 ms or
@@ -359,7 +362,8 @@ public:
 
     All error conditions are fatal unless otherwise specified.
 
-    \param [in] timeout         Max. allowed time for the operation to complete
+    \param [in] timeout         Max. allowed time for the operation to complete.
+                                A negative value means no time limit.
     \param [in] onComplete      Completion handler
 
     \throws std::invalid_argument if `timeout` is less than 1 ms or
@@ -407,7 +411,8 @@ public:
     \param [in] stepID          The ID of the time step to be performed
     \param [in] currentT        The current time point
     \param [in] deltaT          The step size
-    \param [in] timeout         Max. allowed time for the operation to complete
+    \param [in] timeout         Max. allowed time for the operation to complete.
+                                A negative value means no time limit.
     \param [in] onComplete      Completion handler
 
     \throws std::invalid_argument if `timeout` is less than 1 ms or
@@ -451,7 +456,8 @@ public:
       - `coral::error::generic_error::failed`: The operation failed (e.g. due to
             an error in the slave).
 
-    \param [in] timeout         Max. allowed time for the operation to complete
+    \param [in] timeout         Max. allowed time for the operation to complete.
+                                A negative value means no time limit.
     \param [in] onComplete      Completion handler
 
     \throws std::invalid_argument if `timeout` is less than 1 ms or
@@ -546,7 +552,8 @@ an exception.
 \param [in] maxAttempts     The maximum number of times to attempt a connection.
                             Must be at least 1.
 \param [in] timeout         The maximum time to wait for a reply from the slave
-                            for each connection attempt.  Must be at least 1 ms.
+                            for each connection attempt.
+                            A negative value means no time limit.
 \param [in] onComplete      Completion handler.  May not be null.
 
 \throws std::invalid_argument if any of the arguments are invalid.

--- a/src/include/coral/bus/slave_controller.hpp
+++ b/src/include/coral/bus/slave_controller.hpp
@@ -71,6 +71,7 @@ public:
         Slave configuration parameters.
     \param [in] timeout
         Max. allowed time for the slave to reply to each message sent to it.
+        A negative value means no time limit.
     \param [in] onComplete
         Completion handler.
     \param [in] maxConnectionAttempts
@@ -78,8 +79,7 @@ public:
         first one, so the value must be at least 1. The default is 3.
 
     \throws std::invalid_argument if `slaveLocator` is empty, if `slaveID` is
-        invalid, if `timeout` is less than 1 ms, if `onComplete` is empty,
-        or if `maxConnectionAttempts < 1`.
+        invalid, if `onComplete` is empty, or if `maxConnectionAttempts < 1`.
     */
     SlaveController(
         coral::net::Reactor& reactor,
@@ -125,7 +125,8 @@ public:
     \brief  Requests a description of the slave.
 
     \param [in] timeout
-        Max. allowed time for the operation to complete. Must be at least 1 ms.
+        Max. allowed time for the operation to complete.
+        A negative value means no time limit.
     \param [in] onComplete
         Completion handler. May not be empty.
     */
@@ -143,7 +144,8 @@ public:
     \param [in] settings
         A list of variable values and connections. May not be empty.
     \param [in] timeout
-        Max. allowed time for the operation to complete. Must be at least 1 ms.
+        Max. allowed time for the operation to complete.
+        A negative value means no time limit.
     \param [in] onComplete
         Completion handler.
     */
@@ -162,7 +164,8 @@ public:
     \param [in] peers
         A list of peer endpoint specifications.
     \param [in] timeout
-        Max. allowed time for the operation to complete. Must be at least 1 ms.
+        Max. allowed time for the operation to complete.
+        A negative value means no time limit.
     \param [in] onComplete
         Completion handler.
     */
@@ -179,7 +182,8 @@ public:
             values for all connected input variables.
 
     \param [in] timeout
-        Max. allowed time for the operation to complete. Must be at least 1 ms.
+        Max. allowed time for the operation to complete.
+        A negative value means no time limit.
     \param [in] onComplete
         Completion handler.
 
@@ -206,7 +210,8 @@ public:
     \param [in] deltaT
         The step size. Must be positive.
     \param [in] timeout
-        Max. allowed time for the operation to complete. Must be at least 1 ms.
+        Max. allowed time for the operation to complete.
+        A negative value means no time limit.
     \param [in] onComplete
         Completion handler.
     */
@@ -225,7 +230,8 @@ public:
             update its inputs with results from other slaves.
 
     \param [in] timeout
-        Max. allowed time for the operation to complete. Must be at least 1 ms.
+        Max. allowed time for the operation to complete.
+        A negative value means no time limit.
     \param [in] onComplete
         Completion handler.
     */

--- a/src/include/coral/bus/slave_provider_comm.hpp
+++ b/src/include/coral/bus/slave_provider_comm.hpp
@@ -77,6 +77,7 @@ public:
         code in case of failure.
     \param [in] timeout
         Maximum time allowed for the request to complete.
+        A negative value means that there is no time limit.
     */
     void GetSlaveTypes(
         GetSlaveTypesHandler onComplete,
@@ -96,18 +97,21 @@ public:
         The slave type identifier.
     \param [in] instantiationTimeout
         The max allowed time for the slave to start up.
+        A negative value means that there is no time limit (which is somewhat
+        risky, because it means that the entire slave provider will freeze
+        if the slave hangs during startup).
+    \param [in] requestTimeout
+        Additional time allowed for the whole request to complete.
+        A negative value means that there is no time limit.
     \param [in] onComplete
         Function which is called with the slave address when the slave has
         been instantiated, or with an error code and message in case of failure.
-    \param [in] requestTimeout
-        Maximum time allowed for the request to complete, which must of course
-        be greater than `instantiationTimeout`.
     */
     void InstantiateSlave(
         const std::string& slaveTypeUUID,
         std::chrono::milliseconds instantiationTimeout,
-        InstantiateSlaveHandler onComplete,
-        std::chrono::milliseconds requestTimeout = std::chrono::milliseconds(0));
+        std::chrono::milliseconds requestTimeout,
+        InstantiateSlaveHandler onComplete);
 
 private:
     class Private;

--- a/src/include/coral/net/reqrep.hpp
+++ b/src/include/coral/net/reqrep.hpp
@@ -128,6 +128,7 @@ public:
         How long to wait to be able to send the request before throwing an
         exception, or, if the actual sending was successful, how long to wait
         for a reply before calling `onComplete` with an error code.
+        A negative value means "indefinitely".
     \param [in] onComplete
         A callback that will be called when the server responds or the request
         times out.  This function is guaranteed to be called unless Request()
@@ -178,6 +179,7 @@ public:
         How long to wait to be able to send the request before throwing an
         exception, or, if the actual sending was successful, how long to wait
         for a reply before calling `onComplete` with an error code.
+        A negative value means "indefinitely".
     \param [in] onComplete
         A callback that will be called when the server responds or the request
         times out.  This function is guaranteed to be called unless

--- a/src/include/coral/net/zmqx.hpp
+++ b/src/include/coral/net/zmqx.hpp
@@ -78,8 +78,9 @@ std::uint16_t EndpointPort(const std::string& endpoint);
 \brief  Waits up to `timeout` milliseconds to see if a message may be enqueued
         on `socket`.
 
+If `timeout` is negative, the function will wait indefinitely.
+
 \returns whether a message may be immediately enqueued on `socket`.
-\throws std::invalid_argument if `timeout` is negative.
 \throws zmq::error_t on communications error.
 */
 bool WaitForOutgoing(zmq::socket_t& socket, std::chrono::milliseconds timeout);
@@ -88,8 +89,9 @@ bool WaitForOutgoing(zmq::socket_t& socket, std::chrono::milliseconds timeout);
 /**
 \brief  Waits up to `timeout` milliseconds for incoming messages on `socket`.
 
+If `timeout` is negative, the function will wait indefinitely.
+
 \returns whether there are incoming messages on `socket`.
-\throws std::invalid_argument if `timeout` is negative.
 \throws zmq::error_t on communications error.
 */
 bool WaitForIncoming(zmq::socket_t& socket, std::chrono::milliseconds timeout);

--- a/src/lib/bus_execution_state.cpp
+++ b/src/lib/bus_execution_state.cpp
@@ -539,6 +539,10 @@ PrimingExecutionState::PrimingExecutionState(
     , m_commTimeout{commTimeout}
     , m_onComplete{onComplete}
 {
+    // An infinite timeout really does not work here, as the whole point
+    // is to time out and try again if some slaves are not in contact
+    // with each other.
+    assert(commTimeout >= std::chrono::milliseconds(0));
 }
 
 

--- a/src/lib/bus_slave_agent.cpp
+++ b/src/lib/bus_slave_agent.cpp
@@ -426,13 +426,15 @@ SlaveAgent::Timeout::Timeout(
 
 SlaveAgent::Timeout::~Timeout() CORAL_NOEXCEPT
 {
-    SetTimeout(std::chrono::milliseconds(0));
+    SetTimeout(std::chrono::milliseconds(-1));
 }
 
 
 void SlaveAgent::Timeout::Reset()
 {
-    m_reactor.RestartTimerInterval(m_timerID);
+    if (m_timerID != coral::net::Reactor::invalidTimerID) {
+        m_reactor.RestartTimerInterval(m_timerID);
+    }
 }
 
 
@@ -442,7 +444,7 @@ void SlaveAgent::Timeout::SetTimeout(std::chrono::milliseconds timeout)
         m_reactor.RemoveTimer(m_timerID);
         m_timerID = coral::net::Reactor::invalidTimerID;
     }
-    if (timeout > std::chrono::milliseconds(0)) {
+    if (timeout >= std::chrono::milliseconds(0)) {
         m_timerID = m_reactor.AddTimer(
             timeout,
             1,

--- a/src/lib/bus_slave_control_messenger_v0.cpp
+++ b/src/lib/bus_slave_control_messenger_v0.cpp
@@ -277,8 +277,9 @@ void SlaveControlMessengerV0::Setup(
     data.set_execution_name(setup.executionName);
     data.set_slave_name(slaveName);
     data.set_variable_recv_timeout_ms(
-        boost::numeric_cast<google::protobuf::int32>(
-            setup.variableRecvTimeout.count()));
+        setup.variableRecvTimeout >= std::chrono::milliseconds(0)
+            ? boost::numeric_cast<google::protobuf::int32>(setup.variableRecvTimeout.count())
+            : -1);
     SendCommand(coralproto::execution::MSG_SETUP, &data, timeout, std::move(onComplete));
     assert(State() == SLAVE_BUSY);
 }

--- a/src/lib/bus_slave_setup.cpp
+++ b/src/lib/bus_slave_setup.cpp
@@ -34,7 +34,6 @@ SlaveSetup::SlaveSetup(
       variableRecvTimeout(variableRecvTimeout_)
 {
     assert(startTime <= stopTime);
-    assert(variableRecvTimeout > std::chrono::milliseconds(0));
 }
 
 

--- a/src/lib/master_cluster.cpp
+++ b/src/lib/master_cluster.cpp
@@ -388,6 +388,7 @@ void HandleInstantiateSlave(
         slaveProvider->second.InstantiateSlave(
             slaveTypeUUID,
             instantiationTimeout,
+            commTimeout,
             [sharedPromise] (
                 const std::error_code& ec,
                 const coral::net::SlaveLocator& locator,
@@ -399,8 +400,7 @@ void HandleInstantiateSlave(
                     sharedPromise->set_exception(std::make_exception_ptr(
                         std::runtime_error(ec.message() + " (" + errorMessage + ")")));
                 }
-            },
-            commTimeout);
+            });
     } catch (...) {
         sharedPromise->set_exception(std::current_exception());
     }

--- a/src/lib/net_reqrep.cpp
+++ b/src/lib/net_reqrep.cpp
@@ -84,7 +84,9 @@ void Client::Request(
         requestHeader, requestHeaderSize,
         requestBody, requestBodySize,
         timeout);
-    SetTimer(timeout);
+    if (timeout >= std::chrono::milliseconds(0)) {
+        SetTimer(timeout);
+    }
     m_requestProtocolVersion = protocolVersion;
     m_onComplete = std::move(onComplete);
 }
@@ -104,7 +106,9 @@ void Client::RequestMaxProtocol(
         META_REQ_MAX_PROTOCOL_VERSION.data(), META_REQ_MAX_PROTOCOL_VERSION.size(),
         m_protocolIdentifier.data(), m_protocolIdentifier.size(),
         timeout);
-    SetTimer(timeout);
+    if (timeout >= std::chrono::milliseconds(0)) {
+        SetTimer(timeout);
+    }
     m_requestProtocolVersion = protocolVersion;
     m_onMaxProtocolComplete = std::move(onComplete);
 }
@@ -117,6 +121,7 @@ void Client::SendRequest(
     std::chrono::milliseconds timeout)
 {
     assert(!protocolIdentifier.empty());
+    assert(protocolVersion != INVALID_PROTOCOL_VERSION);
     assert(requestHeader != nullptr);
 
     std::vector<zmq::message_t> msg;
@@ -177,7 +182,7 @@ void Client::ReceiveReply()
     m_socket.Receive(msg);
     if (!m_onComplete && !m_onMaxProtocolComplete) return;
 
-    CancelTimer();
+    if (m_timeoutTimerID != NO_TIMER) CancelTimer();
 
     if (msg.size() < 2 || msg[0].size() < 3) {
         CompleteWithError(make_error_code(std::errc::bad_message));
@@ -226,6 +231,7 @@ void Client::CompleteWithError(const std::error_code& ec)
 void Client::SetTimer(std::chrono::milliseconds timeout)
 {
     assert(m_timeoutTimerID == NO_TIMER);
+    assert(timeout >= std::chrono::milliseconds(0));
     m_timeoutTimerID = m_reactor.AddTimer(timeout, 1,
         [this] (coral::net::Reactor&, int) {
             m_timeoutTimerID = NO_TIMER;

--- a/src/lib/net_zmqx_messaging.cpp
+++ b/src/lib/net_zmqx_messaging.cpp
@@ -4,8 +4,13 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
+#ifdef _WIN32
+#   define NOMINMAX
+#endif
+
 #include "coral/net/zmqx.hpp"
 
+#include <algorithm>
 #include "coral/config.h"
 #include "coral/error.hpp"
 
@@ -17,9 +22,9 @@ namespace
         short events,
         std::chrono::milliseconds timeout)
     {
-        assert(timeout >= std::chrono::milliseconds(0));
+        const auto timeout_ms = std::max(static_cast<long>(timeout.count()), -1L);
         auto pollItem = zmq::pollitem_t{static_cast<void*>(socket), 0, events, 0};
-        return zmq::poll(&pollItem, 1, static_cast<long>(timeout.count())) == 1;
+        return zmq::poll(&pollItem, 1, timeout_ms) == 1;
     }
 }
 
@@ -28,7 +33,6 @@ bool coral::net::zmqx::WaitForOutgoing(
     zmq::socket_t& socket,
     std::chrono::milliseconds timeout)
 {
-    CORAL_INPUT_CHECK(timeout >= std::chrono::milliseconds(0));
     return PollSingleSocket(socket, ZMQ_POLLOUT, timeout);
 }
 
@@ -37,7 +41,6 @@ bool coral::net::zmqx::WaitForIncoming(
     zmq::socket_t& socket,
     std::chrono::milliseconds timeout)
 {
-    CORAL_INPUT_CHECK(timeout >= std::chrono::milliseconds(0));
     return PollSingleSocket(socket, ZMQ_POLLIN, timeout);
 }
 

--- a/src/master/config_parser.cpp
+++ b/src/master/config_parser.cpp
@@ -556,7 +556,9 @@ ExecutionConfig ParseExecutionConfig(const std::string& path)
     if (auto commTimeoutNode = ptree.get_child_optional("comm_timeout_ms")) {
         ec.commTimeout = std::chrono::milliseconds(
             commTimeoutNode->get_value<typename std::chrono::milliseconds::rep>());
-        if (ec.commTimeout <= std::chrono::milliseconds(0)) Error("Nonpositive comm_timeout_ms");
+        if (ec.commTimeout < std::chrono::milliseconds(-1)) {
+            Error("Invalid comm_timeout_ms");
+        }
     }
 
     if (auto stepTimeoutMultiplierNode = ptree.get_child_optional("step_timeout_multiplier")) {

--- a/src/master/config_parser.cpp
+++ b/src/master/config_parser.cpp
@@ -569,7 +569,9 @@ ExecutionConfig ParseExecutionConfig(const std::string& path)
     if (auto instTimeoutNode = ptree.get_child_optional("instantiation_timeout_ms")) {
         ec.instantiationTimeout = std::chrono::milliseconds(
             instTimeoutNode->get_value<typename std::chrono::milliseconds::rep>());
-        if (ec.commTimeout <= std::chrono::milliseconds(0)) Error("Nonpositive instantiation_timeout_ms");
+        if (ec.instantiationTimeout < std::chrono::milliseconds(-1)) {
+            Error("Invalid instantiation_timeout_ms");
+        }
     }
     return ec;
 }

--- a/src/master/main.cpp
+++ b/src/master/main.cpp
@@ -112,7 +112,10 @@ int Run(const std::vector<std::string>& args)
             "      ; instantiation command is issued to when the slave is ready for\n"
             "      ; simulation.  Some slaves may take a long time to instantiate, either\n"
             "      ; because the FMU is very large and thus takes a long time to unpack\n"
-            "      ; or because its instantiation routine is very demanding.\n"
+            "      ; or because its instantiation routine is very demanding.  -1 is a\n"
+            "      ; special value which means \"wait indefinitely\".  This is somewhat\n"
+            "      ; risky, however, because it means the entire slave provider will\n"
+            "      ; hang if a slave hangs or crashes during startup.\n"
             "      instantiation_timeout_ms 10000\n");
         if (!argValues) return 0;
 

--- a/src/provider/main.cpp
+++ b/src/provider/main.cpp
@@ -186,10 +186,10 @@ try {
             "The master must listen on the same port.")
         ("slave-exe", po::value<std::string>(),
             "The path to the slave executable")
-        ("timeout", po::value<unsigned int>()->default_value(3600),
+        ("timeout", po::value<int>()->default_value(3600),
             "The number of seconds slaves should wait for commands from a master "
             "before assuming that the connection is broken and shutting themselves "
-            "down.");
+            "down.  The special value -1 means \"never\".");
     po::options_description positionalOptions("Arguments");
     positionalOptions.add_options()
         ("fmu",       po::value<std::vector<std::string>>(), "The FMU files and directories");
@@ -216,7 +216,10 @@ try {
     const auto outputDir = (*optionValues)["output-dir"].as<std::string>();
     const auto discoveryPort = coral::net::ip::Port{
         (*optionValues)["port"].as<std::uint16_t>()};
-    const auto timeout = std::chrono::seconds((*optionValues)["timeout"].as<unsigned int>());
+    const auto timeout = std::chrono::seconds((*optionValues)["timeout"].as<int>());
+    if (timeout < std::chrono::seconds(-1)) {
+        throw std::runtime_error("Invalid timeout value");
+    }
 
     std::string slaveExe;
     if (optionValues->count("slave-exe")) {


### PR DESCRIPTION
This fixes issue #16. All timeouts can now be set to the special value -1 to indicate that there is to be *no* timeout. This should mainly be used for debugging, though, as it could easily cause Coral to freeze because some component is waiting for data which never comes.