### PR TITLE
Prepare to release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Change log
+
+This file documents all notable changes to Coral.  This includes major
+new features, important bug fixes and breaking changes.  For a more
+detailed list of all changes, click the header links for each version.
+This will take you to the relevant sections of the project's
+[Git commit history](https://github.com/viproma/coral).
+
+Coral version numbers follow the [Semantic Versioning](http://semver.org/)
+scheme.  As long as we're still in the initial (pre-1.0) development stage,
+all new versions must be expected to contain backwards-incompatible changes.
+We don't guarantee that they'll all be documented here, but we'll try to
+list the bigger ones.
+
+## [Unreleased]
+
+## [0.8.0] – 2017-03-15
+### Added
+  - A `--realtime` switch to enable soft real time synchronisation in
+    coralmaster.
+  - A `--debug-pause` switch which causes coralmaster to stop at the
+    beginning of the simulation, before any FMI function calls, to allow
+    time to attach a debugger to the slaves.
+  - This CHANGELOG file.
+### Changed
+  - A negative number may now be given for any communication timeout,
+    which will disable the timeout entirely.
+
+## [0.7.1] – 2017-03-09
+### Fixed
+  - Issue [#9](https://github.com/viproma/coral/issues/9):
+    `coral/fmi/importer.hpp` depends on private header
+
+## 0.7.0 – 2017-02-07
+First public release.
+
+[Unreleased]: https://github.com/viproma/coral/compare/v0.8.0...master
+[0.8.0]: https://github.com/viproma/coral/compare/v0.7.1...v0.8.0
+[0.7.1]: https://github.com/viproma/coral/compare/v0.7.0...v0.7.1

--- a/include/coral/config.h
+++ b/include/coral/config.h
@@ -21,7 +21,7 @@ be a valid C header.  C++-specific code should therefore be placed in
 #define CORAL_PROGRAM_NAME "Coral"
 
 #define CORAL_VERSION_MAJOR 0
-#define CORAL_VERSION_MINOR 7
+#define CORAL_VERSION_MINOR 8
 #define CORAL_VERSION_PATCH 0
 
 #define CORAL_VERSION_STRINGIFY(a, b, c) #a "." #b "." #c


### PR DESCRIPTION
I am about to open-source JCoral, the Java interface to Coral. This is a companion release to the first public JCoral release.

This adds a CHANGELOG.md file which will document the more notable changes to Coral in the future.