### PR TITLE
Fix issue where slave types are not cached

### DIFF
--- a/src/lib/bus_slave_provider_comm.cpp
+++ b/src/lib/bus_slave_provider_comm.cpp
@@ -157,12 +157,12 @@ private:
         if (reply == OK_REPLY) {
             coralproto::domain::SlaveTypeList slaveTypeList;
             if (slaveTypeList.ParseFromArray(replyBody, boost::numeric_cast<int>(replyBodySize))) {
-                auto slaveTypes = FromProto(slaveTypeList);
+                m_slaveTypes = FromProto(slaveTypeList);
                 m_slaveTypesCached = true; // TODO: Add "expiry date"?
                 completionHandler(
                     std::error_code{},
-                    slaveTypes.data(),
-                    slaveTypes.size());
+                    m_slaveTypes.data(),
+                    m_slaveTypes.size());
             } else {
                 completionHandler(
                     make_error_code(std::errc::bad_message),


### PR DESCRIPTION
`SlaveProviderClient` is supposed to cache the list of slave types it receives from a slave provider, so it doesn't have to send a new request the next time `GetSlaveTypes()` is called.

However, the slave type list was assigned to a *local* variable (`slaveTypes`) rather than the appropriate member variable (`m_slaveTypes`), while still setting the `m_slaveTypesCached` variable to `true`.  This made it appear as though the slave types had been stored, causing `GetSlaveTypes()` to return an empty list the next time it was called.

This issue was originally reported in JIRA as VIPROMA-132.