### PR TITLE
Change default network interface to 127.0.0.1 in coralmaster and coralslaveprovider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ list the bigger ones.
 ### Changed
   - A negative number may now be given for any communication timeout,
     which will disable the timeout entirely.
+  - The default network interface in coralmaster and coralslaveprovider
+    has been changed from `*` to `127.0.0.1`.
+    (See issue [#20](https://github.com/viproma/coral/issues/20).)
 
 ## [0.7.1] – 2017-03-09
 ### Fixed

--- a/src/master/main.cpp
+++ b/src/master/main.cpp
@@ -26,7 +26,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 namespace {
     const std::string self = "coralmaster";
-    const std::string DEFAULT_NETWORK_INTERFACE = "*";
+    const std::string DEFAULT_NETWORK_INTERFACE = "127.0.0.1";
     const std::uint16_t DEFAULT_DISCOVERY_PORT = 10272;
 }
 

--- a/src/provider/main.cpp
+++ b/src/provider/main.cpp
@@ -30,7 +30,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 namespace
 {
-    const std::string DEFAULT_NETWORK_INTERFACE = "*";
+    const std::string DEFAULT_NETWORK_INTERFACE = "127.0.0.1";
     const std::uint16_t DEFAULT_DISCOVERY_PORT = 10272;
 #ifdef _WIN32
     const std::string DEFAULT_SLAVE_EXE = "coralslave.exe";


### PR DESCRIPTION
This addresses issue #20.