### PR TITLE
Change #include to use angle brackets

### DIFF
--- a/include/coral/bus/variable_io.hpp
+++ b/include/coral/bus/variable_io.hpp
@@ -17,8 +17,8 @@
 #include <string>
 #include <unordered_map>
 
-#include "coral/model.hpp"
-#include "coral/net.hpp"
+#include <coral/model.hpp>
+#include <coral/net.hpp>
 
 
 // Forward declaration to avoid dependency on ZMQ headers

--- a/include/coral/fmi.hpp
+++ b/include/coral/fmi.hpp
@@ -10,10 +10,10 @@
 #ifndef CORAL_FMI_HPP_INCLUDED
 #define CORAL_FMI_HPP_INCLUDED
 
-#include "coral/fmi/fmu.hpp"
-#include "coral/fmi/fmu1.hpp"
-#include "coral/fmi/fmu2.hpp"
-#include "coral/fmi/importer.hpp"
+#include <coral/fmi/fmu.hpp>
+#include <coral/fmi/fmu1.hpp>
+#include <coral/fmi/fmu2.hpp>
+#include <coral/fmi/importer.hpp>
 
 
 namespace coral

--- a/include/coral/fmi/fmu.hpp
+++ b/include/coral/fmi/fmu.hpp
@@ -10,8 +10,8 @@
 #ifndef CORAL_FMI_FMU_HPP
 #define CORAL_FMI_FMU_HPP
 
-#include "coral/model.hpp"
-#include "coral/slave/instance.hpp"
+#include <coral/model.hpp>
+#include <coral/slave/instance.hpp>
 
 
 namespace coral

--- a/include/coral/log.hpp
+++ b/include/coral/log.hpp
@@ -11,8 +11,8 @@
 #define CORAL_LOG_HPP
 
 #include <string>
-#include "boost/format.hpp"
-#include "coral/config.h"
+#include <boost/format.hpp>
+#include <coral/config.h>
 
 
 namespace coral

--- a/include/coral/master.hpp
+++ b/include/coral/master.hpp
@@ -10,8 +10,8 @@
 #ifndef CORAL_MASTER_HPP_INCLUDED
 #define CORAL_MASTER_HPP_INCLUDED
 
-#include "coral/master/cluster.hpp"
-#include "coral/master/execution.hpp"
+#include <coral/master/cluster.hpp>
+#include <coral/master/execution.hpp>
 
 
 namespace coral

--- a/include/coral/master/cluster.hpp
+++ b/include/coral/master/cluster.hpp
@@ -16,9 +16,9 @@
 #include <string>
 #include <vector>
 
-#include "coral/config.h"
-#include "coral/model.hpp"
-#include "coral/net.hpp"
+#include <coral/config.h>
+#include <coral/model.hpp>
+#include <coral/net.hpp>
 
 
 namespace coral

--- a/include/coral/master/execution.hpp
+++ b/include/coral/master/execution.hpp
@@ -17,10 +17,10 @@
 #include <string>
 #include <vector>
 
-#include "coral/config.h"
-#include "coral/master/execution_options.hpp"
-#include "coral/model.hpp"
-#include "coral/net.hpp"
+#include <coral/config.h>
+#include <coral/master/execution_options.hpp>
+#include <coral/model.hpp>
+#include <coral/net.hpp>
 
 
 namespace coral

--- a/include/coral/master/execution_options.hpp
+++ b/include/coral/master/execution_options.hpp
@@ -11,7 +11,7 @@
 #define CORAL_MASTER_EXECUTION_OPTIONS_HPP
 
 #include <chrono>
-#include "coral/model.hpp"
+#include <coral/model.hpp>
 
 
 namespace coral

--- a/include/coral/model.hpp
+++ b/include/coral/model.hpp
@@ -17,10 +17,10 @@
 #include <string>
 #include <vector>
 
-#include "boost/range/adaptor/map.hpp"
-#include "boost/variant.hpp"
+#include <boost/range/adaptor/map.hpp>
+#include <boost/variant.hpp>
 
-#include "coral/config.h"
+#include <coral/config.h>
 
 
 namespace coral

--- a/include/coral/net.hpp
+++ b/include/coral/net.hpp
@@ -20,7 +20,7 @@
 #include <cstdint>
 #include <string>
 
-#include "coral/config.h"
+#include <coral/config.h>
 
 
 namespace coral

--- a/include/coral/provider.hpp
+++ b/include/coral/provider.hpp
@@ -11,8 +11,8 @@
 #ifndef CORAL_PROVIDER_HPP_INCLUDED
 #define CORAL_PROVIDER_HPP_INCLUDED
 
-#include "coral/provider/provider.hpp"
-#include "coral/provider/slave_creator.hpp"
+#include <coral/provider/provider.hpp>
+#include <coral/provider/slave_creator.hpp>
 
 
 namespace coral

--- a/include/coral/provider/provider.hpp
+++ b/include/coral/provider/provider.hpp
@@ -17,8 +17,8 @@
 #include <thread>
 #include <vector>
 
-#include "coral/config.h"
-#include "coral/provider/slave_creator.hpp"
+#include <coral/config.h>
+#include <coral/provider/slave_creator.hpp>
 
 
 // Forward declaration to avoid dependency on ZMQ headers

--- a/include/coral/provider/slave_creator.hpp
+++ b/include/coral/provider/slave_creator.hpp
@@ -13,8 +13,8 @@
 #include <chrono>
 #include <string>
 
-#include "coral/model.hpp"
-#include "coral/net.hpp"
+#include <coral/model.hpp>
+#include <coral/net.hpp>
 
 
 namespace coral

--- a/include/coral/slave.hpp
+++ b/include/coral/slave.hpp
@@ -10,10 +10,10 @@
 #ifndef CORAL_SLAVE_HPP_INCLUDED
 #define CORAL_SLAVE_HPP_INCLUDED
 
-#include "coral/slave/exception.hpp"
-#include "coral/slave/instance.hpp"
-#include "coral/slave/logging.hpp"
-#include "coral/slave/runner.hpp"
+#include <coral/slave/exception.hpp>
+#include <coral/slave/instance.hpp>
+#include <coral/slave/logging.hpp>
+#include <coral/slave/runner.hpp>
 
 
 namespace coral

--- a/include/coral/slave/exception.hpp
+++ b/include/coral/slave/exception.hpp
@@ -13,7 +13,7 @@
 #include <chrono>
 #include <stdexcept>
 #include <string>
-#include "coral/config.h"
+#include <coral/config.h>
 
 
 namespace coral

--- a/include/coral/slave/instance.hpp
+++ b/include/coral/slave/instance.hpp
@@ -11,7 +11,7 @@
 #define CORAL_SLAVE_INSTANCE_HPP
 
 #include <string>
-#include "coral/model.hpp"
+#include <coral/model.hpp>
 
 namespace coral
 {

--- a/include/coral/slave/logging.hpp
+++ b/include/coral/slave/logging.hpp
@@ -14,7 +14,7 @@
 #include <memory>
 #include <string>
 
-#include "coral/slave/instance.hpp"
+#include <coral/slave/instance.hpp>
 
 
 namespace coral

--- a/include/coral/slave/runner.hpp
+++ b/include/coral/slave/runner.hpp
@@ -12,9 +12,9 @@
 
 #include <chrono>
 #include <memory>
-#include "coral/config.h"
-#include "coral/net.hpp"
-#include "coral/slave/instance.hpp"
+#include <coral/config.h>
+#include <coral/net.hpp>
+#include <coral/slave/instance.hpp>
 
 
 namespace coral

--- a/src/include/coral/async.hpp
+++ b/src/include/coral/async.hpp
@@ -18,14 +18,14 @@
 #include <thread>
 #include <utility>
 
-#include "zmq.hpp"
+#include <zmq.hpp>
 
-#include "coral/config.h"
-#include "coral/error.hpp"
-#include "coral/log.hpp"
-#include "coral/net/reactor.hpp"
-#include "coral/net/zmqx.hpp"
-#include "coral/util.hpp"
+#include <coral/config.h>
+#include <coral/error.hpp>
+#include <coral/log.hpp>
+#include <coral/net/reactor.hpp>
+#include <coral/net/zmqx.hpp>
+#include <coral/util.hpp>
 
 
 namespace coral

--- a/src/include/coral/bus/execution_manager.hpp
+++ b/src/include/coral/bus/execution_manager.hpp
@@ -17,16 +17,16 @@
 #include <utility>
 #include <vector>
 
-#include "boost/noncopyable.hpp"
+#include <boost/noncopyable.hpp>
 
-#include "coral/config.h"
-#include "coral/master/execution_options.hpp"
-#include "coral/model.hpp"
-#include "coral/net.hpp"
+#include <coral/config.h>
+#include <coral/master/execution_options.hpp>
+#include <coral/model.hpp>
+#include <coral/net.hpp>
 
-#include "coral/bus/slave_controller.hpp"
-#include "coral/bus/slave_setup.hpp"
-#include "coral/net/reactor.hpp"
+#include <coral/bus/slave_controller.hpp>
+#include <coral/bus/slave_setup.hpp>
+#include <coral/net/reactor.hpp>
 
 
 namespace coral

--- a/src/include/coral/bus/execution_manager_private.hpp
+++ b/src/include/coral/bus/execution_manager_private.hpp
@@ -18,15 +18,15 @@
 #include <memory>
 #include <system_error>
 
-#include "boost/noncopyable.hpp"
+#include <boost/noncopyable.hpp>
 
-#include "coral/config.h"
-#include "coral/model.hpp"
-#include "coral/net.hpp"
+#include <coral/config.h>
+#include <coral/model.hpp>
+#include <coral/net.hpp>
 
-#include "coral/bus/execution_manager.hpp"
-#include "coral/bus/slave_controller.hpp"
-#include "coral/bus/slave_setup.hpp"
+#include <coral/bus/execution_manager.hpp>
+#include <coral/bus/slave_controller.hpp>
+#include <coral/bus/slave_setup.hpp>
 
 
 namespace coral

--- a/src/include/coral/bus/execution_state.hpp
+++ b/src/include/coral/bus/execution_state.hpp
@@ -14,9 +14,9 @@
 // For the sake of maintainability, we can skip the headers which are already
 // included by execution_manager.hpp, and which are only needed here because
 // ExecutionState duplicates ExecutionManager's method signatures.
-#include "coral/bus/execution_manager.hpp"
-#include "coral/config.h"
-#include "coral/error.hpp"
+#include <coral/bus/execution_manager.hpp>
+#include <coral/config.h>
+#include <coral/error.hpp>
 
 
 namespace coral

--- a/src/include/coral/bus/slave_agent.hpp
+++ b/src/include/coral/bus/slave_agent.hpp
@@ -15,18 +15,18 @@
 #include <string>
 #include <vector>
 
-#include "boost/bimap.hpp"
-#include "boost/bimap/multiset_of.hpp"
-#include "zmq.hpp"
+#include <boost/bimap.hpp>
+#include <boost/bimap/multiset_of.hpp>
+#include <zmq.hpp>
 
-#include "coral/config.h"
-#include "coral/bus/variable_io.hpp"
-#include "coral/model.hpp"
-#include "coral/net.hpp"
-#include "coral/net/reactor.hpp"
-#include "coral/net/zmqx.hpp"
-#include "coral/slave/instance.hpp"
-#include "execution.pb.h"
+#include <coral/config.h>
+#include <coral/bus/variable_io.hpp>
+#include <coral/model.hpp>
+#include <coral/net.hpp>
+#include <coral/net/reactor.hpp>
+#include <coral/net/zmqx.hpp>
+#include <coral/slave/instance.hpp>
+#include <execution.pb.h>
 
 
 namespace coral

--- a/src/include/coral/bus/slave_control_messenger.hpp
+++ b/src/include/coral/bus/slave_control_messenger.hpp
@@ -21,14 +21,14 @@ stuff in this header.
 #include <system_error>
 #include <vector>
 
-#include "boost/noncopyable.hpp"
+#include <boost/noncopyable.hpp>
 
-#include "coral/config.h"
+#include <coral/config.h>
 
-#include "coral/bus/slave_setup.hpp"
-#include "coral/net/reactor.hpp"
-#include "coral/model.hpp"
-#include "coral/net.hpp"
+#include <coral/bus/slave_setup.hpp>
+#include <coral/net/reactor.hpp>
+#include <coral/model.hpp>
+#include <coral/net.hpp>
 
 
 namespace coral

--- a/src/include/coral/bus/slave_control_messenger_v0.hpp
+++ b/src/include/coral/bus/slave_control_messenger_v0.hpp
@@ -13,15 +13,15 @@
 #include <chrono>
 #include <memory>
 
-#include "coral/config.h"
-#include "coral/bus/slave_control_messenger.hpp"
-#include "coral/bus/slave_setup.hpp"
-#include "coral/model.hpp"
-#include "coral/net.hpp"
-#include "coral/net/reactor.hpp"
-#include "coral/net/zmqx.hpp"
+#include <coral/config.h>
+#include <coral/bus/slave_control_messenger.hpp>
+#include <coral/bus/slave_setup.hpp>
+#include <coral/model.hpp>
+#include <coral/net.hpp>
+#include <coral/net/reactor.hpp>
+#include <coral/net/zmqx.hpp>
 
-#include "boost/variant.hpp"
+#include <boost/variant.hpp>
 
 
 // Forward declaration to avoid header dependency

--- a/src/include/coral/bus/slave_controller.hpp
+++ b/src/include/coral/bus/slave_controller.hpp
@@ -16,12 +16,12 @@
 #include <system_error>
 #include <vector>
 
-#include "coral/config.h"
-#include "coral/bus/slave_control_messenger.hpp"
-#include "coral/bus/slave_setup.hpp"
-#include "coral/net/reactor.hpp"
-#include "coral/model.hpp"
-#include "coral/net.hpp"
+#include <coral/config.h>
+#include <coral/bus/slave_control_messenger.hpp>
+#include <coral/bus/slave_setup.hpp>
+#include <coral/net/reactor.hpp>
+#include <coral/model.hpp>
+#include <coral/net.hpp>
 
 
 namespace coral

--- a/src/include/coral/bus/slave_provider_comm.hpp
+++ b/src/include/coral/bus/slave_provider_comm.hpp
@@ -17,11 +17,11 @@
 #include <string>
 #include <system_error>
 
-#include "coral/config.h"
-#include "coral/model.hpp"
-#include "coral/net.hpp"
-#include "coral/net/reactor.hpp"
-#include "coral/net/reqrep.hpp"
+#include <coral/config.h>
+#include <coral/model.hpp>
+#include <coral/net.hpp>
+#include <coral/net/reactor.hpp>
+#include <coral/net/reqrep.hpp>
 
 
 namespace coral

--- a/src/include/coral/bus/slave_setup.hpp
+++ b/src/include/coral/bus/slave_setup.hpp
@@ -11,7 +11,7 @@
 #define CORAL_BUS_SLAVE_SETUP_HPP
 
 #include <chrono>
-#include "coral/model.hpp"
+#include <coral/model.hpp>
 
 
 namespace coral

--- a/src/include/coral/error.hpp
+++ b/src/include/coral/error.hpp
@@ -14,7 +14,7 @@
 #include <stdexcept>
 #include <string>
 #include <system_error>
-#include "coral/config.h"
+#include <coral/config.h>
 
 
 namespace coral

--- a/src/include/coral/fmi/glue.hpp
+++ b/src/include/coral/fmi/glue.hpp
@@ -10,8 +10,8 @@
 #ifndef CORAL_FMI_GLUE_HPP
 #define CORAL_FMI_GLUE_HPP
 
-#include "fmilib.h"
-#include "coral/model.hpp"
+#include <fmilib.h>
+#include <coral/model.hpp>
 
 
 namespace coral

--- a/src/include/coral/net/reactor.hpp
+++ b/src/include/coral/net/reactor.hpp
@@ -16,8 +16,8 @@
 #include <vector>
 #include <utility>
 
-#include "zmq.hpp"
-#include "coral/config.h"
+#include <zmq.hpp>
+#include <coral/config.h>
 
 
 namespace coral

--- a/src/include/coral/net/reqrep.hpp
+++ b/src/include/coral/net/reqrep.hpp
@@ -19,12 +19,12 @@
 #include <system_error>
 #include <unordered_map>
 
-#include "zmq.hpp"
+#include <zmq.hpp>
 
-#include "coral/config.h"
-#include "coral/net/reactor.hpp"
-#include "coral/net/zmqx.hpp"
-#include "coral/net.hpp"
+#include <coral/config.h>
+#include <coral/net/reactor.hpp>
+#include <coral/net/zmqx.hpp>
+#include <coral/net.hpp>
 
 
 namespace coral

--- a/src/include/coral/net/service.hpp
+++ b/src/include/coral/net/service.hpp
@@ -16,11 +16,11 @@
 #include <string>
 #include <thread>
 
-#include "zmq.hpp"
+#include <zmq.hpp>
 
-#include "coral/config.h"
-#include "coral/net.hpp"
-#include "coral/net/reactor.hpp"
+#include <coral/config.h>
+#include <coral/net.hpp>
+#include <coral/net/reactor.hpp>
 
 
 namespace coral

--- a/src/include/coral/net/udp.hpp
+++ b/src/include/coral/net/udp.hpp
@@ -20,8 +20,8 @@
 #include <memory>
 #include <string>
 
-#include "coral/config.h"
-#include "coral/net.hpp"
+#include <coral/config.h>
+#include <coral/net.hpp>
 
 
 namespace coral

--- a/src/include/coral/net/zmqx.hpp
+++ b/src/include/coral/net/zmqx.hpp
@@ -17,10 +17,10 @@
 #include <string>
 #include <vector>
 
-#include "zmq.hpp"
+#include <zmq.hpp>
 
-#include "coral/config.h"
-#include "coral/net.hpp"
+#include <coral/config.h>
+#include <coral/net.hpp>
 
 
 namespace coral

--- a/src/include/coral/protobuf.hpp
+++ b/src/include/coral/protobuf.hpp
@@ -11,8 +11,8 @@
 #define CORAL_PROTOBUF_HPP
 
 #include <stdexcept>
-#include "google/protobuf/message_lite.h"
-#include "zmq.hpp"
+#include <google/protobuf/message_lite.h>
+#include <zmq.hpp>
 
 
 namespace coral

--- a/src/include/coral/protocol/domain.hpp
+++ b/src/include/coral/protocol/domain.hpp
@@ -12,8 +12,8 @@
 
 #include <string>
 #include <vector>
-#include "zmq.hpp"
-#include "google/protobuf/message_lite.h"
+#include <zmq.hpp>
+#include <google/protobuf/message_lite.h>
 
 
 namespace coral

--- a/src/include/coral/protocol/exe_data.hpp
+++ b/src/include/coral/protocol/exe_data.hpp
@@ -11,8 +11,8 @@
 #define CORAL_PROTOCOL_EXE_DATA_HPP
 
 #include <vector>
-#include "zmq.hpp"
-#include "coral/model.hpp"
+#include <zmq.hpp>
+#include <coral/model.hpp>
 
 
 namespace coral

--- a/src/include/coral/protocol/execution.hpp
+++ b/src/include/coral/protocol/execution.hpp
@@ -12,9 +12,9 @@
 
 #include <cstdint>
 #include <vector>
-#include "google/protobuf/message_lite.h"
-#include "zmq.hpp"
-#include "execution.pb.h"
+#include <google/protobuf/message_lite.h>
+#include <zmq.hpp>
+#include <execution.pb.h>
 
 
 namespace coral

--- a/src/include/coral/protocol/glue.hpp
+++ b/src/include/coral/protocol/glue.hpp
@@ -10,12 +10,12 @@
 #ifndef CORAL_PROTOCOL_GLUE_HPP
 #define CORAL_PROTOCOL_GLUE_HPP
 
-#include "coral/model.hpp"
-#include "model.pb.h"
-#include "net.pb.h"
+#include <coral/model.hpp>
+#include <model.pb.h>
+#include <net.pb.h>
 
-#include "coral/net.hpp"
-#include "domain.pb.h"
+#include <coral/net.hpp>
+#include <domain.pb.h>
 
 
 namespace coral

--- a/src/include/coral/util.hpp
+++ b/src/include/coral/util.hpp
@@ -15,9 +15,9 @@
 #include <utility>
 #include <vector>
 
-#include "coral/config.h"
-#include "boost/filesystem/path.hpp"
-#include "boost/noncopyable.hpp"
+#include <coral/config.h>
+#include <boost/filesystem/path.hpp>
+#include <boost/noncopyable.hpp>
 
 
 namespace coral

--- a/src/include/coral/util/console.hpp
+++ b/src/include/coral/util/console.hpp
@@ -13,8 +13,8 @@
 #include <ostream>
 #include <string>
 #include <vector>
-#include "boost/optional.hpp"
-#include "boost/program_options.hpp"
+#include <boost/optional.hpp>
+#include <boost/program_options.hpp>
 
 namespace coral
 {

--- a/src/include/coral/util/zip.hpp
+++ b/src/include/coral/util/zip.hpp
@@ -15,10 +15,10 @@
 #include <stdexcept>
 #include <string>
 
-#include "boost/filesystem/path.hpp"
-#include "boost/optional.hpp"
+#include <boost/filesystem/path.hpp>
+#include <boost/optional.hpp>
 
-#include "coral/config.h"
+#include <coral/config.h>
 
 
 // Forward declarations to avoid dependency on zip.h

--- a/src/lib/async.cpp
+++ b/src/lib/async.cpp
@@ -4,7 +4,7 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
-#include "coral/async.hpp"
+#include <coral/async.hpp>
 
 
 namespace coral

--- a/src/lib/async_test.cpp
+++ b/src/lib/async_test.cpp
@@ -1,6 +1,6 @@
 #include <stdexcept>
-#include "gtest/gtest.h"
-#include "coral/async.hpp"
+#include <gtest/gtest.h>
+#include <coral/async.hpp>
 
 namespace
 {

--- a/src/lib/bus_execution_manager.cpp
+++ b/src/lib/bus_execution_manager.cpp
@@ -4,9 +4,9 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
-#include "coral/bus/execution_manager.hpp"
+#include <coral/bus/execution_manager.hpp>
 
-#include "coral/bus/execution_manager_private.hpp"
+#include <coral/bus/execution_manager_private.hpp>
 
 
 namespace coral

--- a/src/lib/bus_execution_manager_private.cpp
+++ b/src/lib/bus_execution_manager_private.cpp
@@ -5,17 +5,17 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 #define NOMINMAX
-#include "coral/bus/execution_manager_private.hpp"
+#include <coral/bus/execution_manager_private.hpp>
 
 #include <cassert>
 #include <typeinfo>
 #include <utility>
 
-#include "boost/numeric/conversion/cast.hpp"
+#include <boost/numeric/conversion/cast.hpp>
 
-#include "coral/bus/execution_state.hpp"
-#include "coral/log.hpp"
-#include "coral/util.hpp"
+#include <coral/bus/execution_state.hpp>
+#include <coral/log.hpp>
+#include <coral/util.hpp>
 
 
 namespace coral

--- a/src/lib/bus_execution_state.cpp
+++ b/src/lib/bus_execution_state.cpp
@@ -5,7 +5,7 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 #define NOMINMAX
-#include "coral/bus/execution_state.hpp"
+#include <coral/bus/execution_state.hpp>
 
 #include <algorithm>
 #include <cassert>
@@ -15,11 +15,11 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #include <string>
 #include <unordered_map>
 
-#include "coral/bus/execution_manager_private.hpp"
-#include "coral/bus/slave_control_messenger.hpp"
-#include "coral/bus/slave_controller.hpp"
-#include "coral/log.hpp"
-#include "coral/util.hpp"
+#include <coral/bus/execution_manager_private.hpp>
+#include <coral/bus/slave_control_messenger.hpp>
+#include <coral/bus/slave_controller.hpp>
+#include <coral/log.hpp>
+#include <coral/util.hpp>
 
 
 namespace coral

--- a/src/lib/bus_slave_agent.cpp
+++ b/src/lib/bus_slave_agent.cpp
@@ -4,20 +4,20 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
-#include "coral/bus/slave_agent.hpp"
+#include <coral/bus/slave_agent.hpp>
 
 #include <cassert>
 #include <limits>
 #include <utility>
 
-#include "coral/error.hpp"
-#include "coral/log.hpp"
-#include "coral/net/zmqx.hpp"
-#include "coral/protobuf.hpp"
-#include "coral/protocol/execution.hpp"
-#include "coral/protocol/glue.hpp"
-#include "coral/slave/exception.hpp"
-#include "coral/util.hpp"
+#include <coral/error.hpp>
+#include <coral/log.hpp>
+#include <coral/net/zmqx.hpp>
+#include <coral/protobuf.hpp>
+#include <coral/protocol/execution.hpp>
+#include <coral/protocol/glue.hpp>
+#include <coral/slave/exception.hpp>
+#include <coral/util.hpp>
 
 
 namespace

--- a/src/lib/bus_slave_control_messenger.cpp
+++ b/src/lib/bus_slave_control_messenger.cpp
@@ -4,16 +4,16 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
-#include "coral/bus/slave_control_messenger.hpp"
+#include <coral/bus/slave_control_messenger.hpp>
 
 #include <cassert>
 #include <utility>
 
-#include "coral/bus/slave_control_messenger_v0.hpp"
-#include "coral/error.hpp"
-#include "coral/log.hpp"
-#include "coral/net/zmqx.hpp"
-#include "coral/protocol/execution.hpp"
+#include <coral/bus/slave_control_messenger_v0.hpp>
+#include <coral/error.hpp>
+#include <coral/log.hpp>
+#include <coral/net/zmqx.hpp>
+#include <coral/protocol/execution.hpp>
 
 
 namespace coral

--- a/src/lib/bus_slave_control_messenger_v0.cpp
+++ b/src/lib/bus_slave_control_messenger_v0.cpp
@@ -4,20 +4,20 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
-#include "coral/bus/slave_control_messenger_v0.hpp"
+#include <coral/bus/slave_control_messenger_v0.hpp>
 
 #include <cassert>
 #include <utility>
 
 #include <boost/numeric/conversion/cast.hpp>
 
-#include "coral/error.hpp"
-#include "coral/log.hpp"
-#include "coral/protobuf.hpp"
-#include "coral/protocol/execution.hpp"
-#include "coral/protocol/glue.hpp"
-#include "coral/util.hpp"
-#include "execution.pb.h"
+#include <coral/error.hpp>
+#include <coral/log.hpp>
+#include <coral/protobuf.hpp>
+#include <coral/protocol/execution.hpp>
+#include <coral/protocol/glue.hpp>
+#include <coral/util.hpp>
+#include <execution.pb.h>
 
 
 namespace coral

--- a/src/lib/bus_slave_controller.cpp
+++ b/src/lib/bus_slave_controller.cpp
@@ -4,11 +4,11 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
-#include "coral/bus/slave_controller.hpp"
+#include <coral/bus/slave_controller.hpp>
 
 #include <cassert>
 #include <utility>
-#include "coral/error.hpp"
+#include <coral/error.hpp>
 
 
 namespace coral

--- a/src/lib/bus_slave_provider_comm.cpp
+++ b/src/lib/bus_slave_provider_comm.cpp
@@ -4,18 +4,18 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
-#include "coral/bus/slave_provider_comm.hpp"
+#include <coral/bus/slave_provider_comm.hpp>
 
 #include <cassert>
 #include <utility>
 #include <vector>
 
-#include "boost/numeric/conversion/cast.hpp"
+#include <boost/numeric/conversion/cast.hpp>
 
-#include "coral/error.hpp"
-#include "coral/log.hpp"
-#include "coral/protocol/glue.hpp"
-#include "domain.pb.h"
+#include <coral/error.hpp>
+#include <coral/log.hpp>
+#include <coral/protocol/glue.hpp>
+#include <domain.pb.h>
 
 
 namespace coral

--- a/src/lib/bus_slave_setup.cpp
+++ b/src/lib/bus_slave_setup.cpp
@@ -4,7 +4,7 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
-#include "coral/bus/slave_setup.hpp"
+#include <coral/bus/slave_setup.hpp>
 
 #include <cassert>
 #include <limits>

--- a/src/lib/bus_variable_io.cpp
+++ b/src/lib/bus_variable_io.cpp
@@ -4,15 +4,15 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
-#include "coral/bus/variable_io.hpp"
+#include <coral/bus/variable_io.hpp>
 
 #include <utility>
-#include "zmq.hpp"
+#include <zmq.hpp>
 
-#include "coral/error.hpp"
-#include "coral/log.hpp"
-#include "coral/net/zmqx.hpp"
-#include "coral/protocol/exe_data.hpp"
+#include <coral/error.hpp>
+#include <coral/log.hpp>
+#include <coral/net/zmqx.hpp>
+#include <coral/protocol/exe_data.hpp>
 
 
 namespace coral

--- a/src/lib/bus_variable_io_test.cpp
+++ b/src/lib/bus_variable_io_test.cpp
@@ -8,14 +8,14 @@
 #include <utility>
 #include <vector>
 
-#include "boost/chrono/duration.hpp"
-#include "boost/thread/barrier.hpp"
-#include "boost/thread/latch.hpp"
-#include "gtest/gtest.h"
+#include <boost/chrono/duration.hpp>
+#include <boost/thread/barrier.hpp>
+#include <boost/thread/latch.hpp>
+#include <gtest/gtest.h>
 
-#include "coral/bus/variable_io.hpp"
-#include "coral/net/zmqx.hpp"
-#include "coral/util.hpp"
+#include <coral/bus/variable_io.hpp>
+#include <coral/net/zmqx.hpp>
+#include <coral/util.hpp>
 
 
 namespace

--- a/src/lib/error.cpp
+++ b/src/lib/error.cpp
@@ -4,7 +4,7 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
-#include "coral/error.hpp"
+#include <coral/error.hpp>
 
 #include <cassert>
 #include <cstring>

--- a/src/lib/error_test.cpp
+++ b/src/lib/error_test.cpp
@@ -1,7 +1,7 @@
 #include <cerrno>
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
-#include "coral/error.hpp"
+#include <coral/error.hpp>
 
 
 TEST(coral_error, ErrnoMessage)

--- a/src/lib/fmi_glue.cpp
+++ b/src/lib/fmi_glue.cpp
@@ -4,7 +4,7 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
-#include "coral/fmi/glue.hpp"
+#include <coral/fmi/glue.hpp>
 
 #include <cassert>
 #include <stdexcept>

--- a/src/lib/fmi_importer.cpp
+++ b/src/lib/fmi_importer.cpp
@@ -4,7 +4,7 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
-#include "coral/fmi/importer.hpp"
+#include <coral/fmi/importer.hpp>
 
 #include <cassert>
 #include <cstdlib>
@@ -12,19 +12,19 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #include <new>
 #include <sstream>
 
-#include "boost/algorithm/string/trim.hpp"
-#include "boost/filesystem.hpp"
-#include "boost/property_tree/ptree.hpp"
-#include "boost/property_tree/xml_parser.hpp"
+#include <boost/algorithm/string/trim.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/xml_parser.hpp>
 
-#include "fmilib.h"
+#include <fmilib.h>
 
-#include "coral/error.hpp"
-#include "coral/fmi/fmu1.hpp"
-#include "coral/fmi/fmu2.hpp"
-#include "coral/log.hpp"
-#include "coral/util.hpp"
-#include "coral/util/zip.hpp"
+#include <coral/error.hpp>
+#include <coral/fmi/fmu1.hpp>
+#include <coral/fmi/fmu2.hpp>
+#include <coral/log.hpp>
+#include <coral/util.hpp>
+#include <coral/util/zip.hpp>
 
 
 namespace coral

--- a/src/lib/log.cpp
+++ b/src/lib/log.cpp
@@ -4,7 +4,7 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
-#include "coral/log.hpp"
+#include <coral/log.hpp>
 
 #include <atomic>
 #include <iostream>

--- a/src/lib/master_cluster.cpp
+++ b/src/lib/master_cluster.cpp
@@ -4,24 +4,24 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
-#include "coral/master/cluster.hpp"
+#include <coral/master/cluster.hpp>
 
 #include <cassert>
 #include <unordered_map>
 
-#include "zmq.hpp"
+#include <zmq.hpp>
 
-#include "coral/async.hpp"
-#include "coral/bus/slave_provider_comm.hpp"
-#include "coral/error.hpp"
-#include "coral/log.hpp"
-#include "coral/net/reactor.hpp"
-#include "coral/net/service.hpp"
-#include "coral/net/zmqx.hpp"
-#include "coral/protocol/glue.hpp"
-#include "coral/util.hpp"
+#include <coral/async.hpp>
+#include <coral/bus/slave_provider_comm.hpp>
+#include <coral/error.hpp>
+#include <coral/log.hpp>
+#include <coral/net/reactor.hpp>
+#include <coral/net/service.hpp>
+#include <coral/net/zmqx.hpp>
+#include <coral/protocol/glue.hpp>
+#include <coral/util.hpp>
 
-#include "domain.pb.h"
+#include <domain.pb.h>
 
 
 namespace coral

--- a/src/lib/master_execution.cpp
+++ b/src/lib/master_execution.cpp
@@ -4,18 +4,18 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
-#include "coral/master/execution.hpp"
+#include <coral/master/execution.hpp>
 
 #include <exception>
 #include <stdexcept>
 #include <utility>
 
-#include "zmq.hpp"
+#include <zmq.hpp>
 
-#include "coral/async.hpp"
-#include "coral/bus/execution_manager.hpp"
-#include "coral/net/reactor.hpp"
-#include "coral/log.hpp"
+#include <coral/async.hpp>
+#include <coral/bus/execution_manager.hpp>
+#include <coral/net/reactor.hpp>
+#include <coral/log.hpp>
 
 
 namespace

--- a/src/lib/model.cpp
+++ b/src/lib/model.cpp
@@ -4,12 +4,12 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
-#include "coral/model.hpp"
+#include <coral/model.hpp>
 
 #include <cctype>
 
-#include "coral/error.hpp"
-#include "coral/util.hpp"
+#include <coral/error.hpp>
+#include <coral/util.hpp>
 
 
 namespace coral

--- a/src/lib/net.cpp
+++ b/src/lib/net.cpp
@@ -7,7 +7,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #ifdef _WIN32
 #   define WIN32_LEAN_AND_MEAN
 #endif
-#include "coral/net.hpp"
+#include <coral/net.hpp>
 
 #ifdef _WIN32
 #   include <ws2tcpip.h>
@@ -19,11 +19,11 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #include <stdexcept>
 #include <utility>
 
-#include "zmq.hpp"
+#include <zmq.hpp>
 
-#include "coral/error.hpp"
-#include "coral/net/ip.hpp"
-#include "coral/net/zmqx.hpp"
+#include <coral/error.hpp>
+#include <coral/net/ip.hpp>
+#include <coral/net/zmqx.hpp>
 
 
 namespace coral

--- a/src/lib/net_ip.cpp
+++ b/src/lib/net_ip.cpp
@@ -4,7 +4,7 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
-#include "coral/net/ip.hpp"
+#include <coral/net/ip.hpp>
 
 #ifdef _WIN32
 #   define WIN32_LEAN_AND_MEAN
@@ -26,7 +26,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #   endif
 #   include <sys/socket.h>
 
-#   include "coral/util.hpp"
+#   include <coral/util.hpp>
 #endif
 
 

--- a/src/lib/net_reactor.cpp
+++ b/src/lib/net_reactor.cpp
@@ -7,11 +7,11 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #ifdef _WIN32
 #   define NOMINMAX
 #endif
-#include "coral/net/reactor.hpp"
+#include <coral/net/reactor.hpp>
 
 #include <algorithm>
 #include <stdexcept>
-#include "coral/util.hpp"
+#include <coral/util.hpp>
 
 
 namespace coral

--- a/src/lib/net_reactor_test.cpp
+++ b/src/lib/net_reactor_test.cpp
@@ -1,6 +1,6 @@
 #include <thread>
-#include "gtest/gtest.h"
-#include "coral/net/reactor.hpp"
+#include <gtest/gtest.h>
+#include <coral/net/reactor.hpp>
 
 using namespace coral::net;
 

--- a/src/lib/net_reqrep.cpp
+++ b/src/lib/net_reqrep.cpp
@@ -4,11 +4,11 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
-#include "coral/net/reqrep.hpp"
+#include <coral/net/reqrep.hpp>
 
-#include "coral/error.hpp"
-#include "coral/net/zmqx.hpp"
-#include "coral/util.hpp"
+#include <coral/error.hpp>
+#include <coral/net/zmqx.hpp>
+#include <coral/util.hpp>
 
 
 namespace coral

--- a/src/lib/net_reqrep_test.cpp
+++ b/src/lib/net_reqrep_test.cpp
@@ -1,8 +1,8 @@
 #include <memory>
 #include <thread>
-#include "gtest/gtest.h"
-#include "coral/net/reqrep.hpp"
-#include "coral/util.hpp"
+#include <gtest/gtest.h>
+#include <coral/net/reqrep.hpp>
+#include <coral/util.hpp>
 
 
 namespace dnr = coral::net::reqrep;

--- a/src/lib/net_service.cpp
+++ b/src/lib/net_service.cpp
@@ -7,7 +7,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #ifdef _WIN32
 #   define NOMINMAX
 #endif
-#include "coral/net/service.hpp"
+#include <coral/net/service.hpp>
 
 #include <algorithm> // std::copy
 #include <cassert>
@@ -17,14 +17,14 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #include <utility>
 #include <vector>
 
-#include "boost/numeric/conversion/cast.hpp"
+#include <boost/numeric/conversion/cast.hpp>
 
-#include "coral/error.hpp"
-#include "coral/log.hpp"
-#include "coral/net/ip.hpp"
-#include "coral/net/udp.hpp"
-#include "coral/net/zmqx.hpp"
-#include "coral/util.hpp"
+#include <coral/error.hpp>
+#include <coral/log.hpp>
+#include <coral/net/ip.hpp>
+#include <coral/net/udp.hpp>
+#include <coral/net/zmqx.hpp>
+#include <coral/util.hpp>
 
 
 namespace coral

--- a/src/lib/net_service_test.cpp
+++ b/src/lib/net_service_test.cpp
@@ -3,8 +3,8 @@
 #endif
 #include <algorithm> // std::max
 #include <memory>
-#include "gtest/gtest.h"
-#include "coral/net/service.hpp"
+#include <gtest/gtest.h>
+#include <coral/net/service.hpp>
 
 
 TEST(coral_net_service, Listener)

--- a/src/lib/net_test.cpp
+++ b/src/lib/net_test.cpp
@@ -1,5 +1,5 @@
-#include "gtest/gtest.h"
-#include "coral/net.hpp"
+#include <gtest/gtest.h>
+#include <coral/net.hpp>
 
 
 TEST(coral_net, Endpoint)

--- a/src/lib/net_udp.cpp
+++ b/src/lib/net_udp.cpp
@@ -4,7 +4,7 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
-#include "coral/net/udp.hpp"
+#include <coral/net/udp.hpp>
 
 #ifdef _WIN32
 #   include <ws2tcpip.h>
@@ -18,9 +18,9 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #include <utility>
 #include <vector>
 
-#include "coral/net/ip.hpp"
-#include "coral/log.hpp"
-#include "coral/util.hpp"
+#include <coral/net/ip.hpp>
+#include <coral/log.hpp>
+#include <coral/util.hpp>
 
 
 namespace

--- a/src/lib/net_zmqx_messaging.cpp
+++ b/src/lib/net_zmqx_messaging.cpp
@@ -8,11 +8,11 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #   define NOMINMAX
 #endif
 
-#include "coral/net/zmqx.hpp"
+#include <coral/net/zmqx.hpp>
 
 #include <algorithm>
-#include "coral/config.h"
-#include "coral/error.hpp"
+#include <coral/config.h>
+#include <coral/error.hpp>
 
 
 namespace

--- a/src/lib/net_zmqx_messaging_test.cpp
+++ b/src/lib/net_zmqx_messaging_test.cpp
@@ -1,7 +1,7 @@
 #include <chrono>
 #include <cstring>
-#include "gtest/gtest.h"
-#include "coral/net/zmqx.hpp"
+#include <gtest/gtest.h>
+#include <coral/net/zmqx.hpp>
 
 using namespace coral::net::zmqx;
 

--- a/src/lib/net_zmqx_sockets.cpp
+++ b/src/lib/net_zmqx_sockets.cpp
@@ -5,14 +5,14 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 #define NOMINMAX
-#include "coral/net/zmqx.hpp"
+#include <coral/net/zmqx.hpp>
 
 #include <cassert>
 #include <stdexcept>
 #include <utility>
 
-#include "coral/config.h"
-#include "coral/error.hpp"
+#include <coral/config.h>
+#include <coral/error.hpp>
 
 
 namespace coral

--- a/src/lib/net_zmqx_sockets_test.cpp
+++ b/src/lib/net_zmqx_sockets_test.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <chrono>
 #include <cstring>
@@ -6,9 +6,9 @@
 #include <thread>
 #include <vector>
 
-#include "zmq.hpp"
+#include <zmq.hpp>
 
-#include "coral/net/zmqx.hpp"
+#include <coral/net/zmqx.hpp>
 
 
 using namespace coral::net::zmqx;

--- a/src/lib/net_zmqx_util.cpp
+++ b/src/lib/net_zmqx_util.cpp
@@ -4,9 +4,9 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
-#include "coral/net/zmqx.hpp"
+#include <coral/net/zmqx.hpp>
 
-#include "boost/lexical_cast.hpp"
+#include <boost/lexical_cast.hpp>
 
 
 namespace coral

--- a/src/lib/net_zmqx_util_test.cpp
+++ b/src/lib/net_zmqx_util_test.cpp
@@ -2,8 +2,8 @@
 #include <string>
 #include <typeinfo> // std::bad_cast
 
-#include "gtest/gtest.h"
-#include "coral/net/zmqx.hpp"
+#include <gtest/gtest.h>
+#include <coral/net/zmqx.hpp>
 
 using namespace coral::net::zmqx;
 

--- a/src/lib/protobuf.cpp
+++ b/src/lib/protobuf.cpp
@@ -4,9 +4,9 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
-#include "coral/protobuf.hpp"
+#include <coral/protobuf.hpp>
 
-#include "boost/numeric/conversion/cast.hpp"
+#include <boost/numeric/conversion/cast.hpp>
 
 
 void coral::protobuf::SerializeToFrame(

--- a/src/lib/protobuf_test.cpp
+++ b/src/lib/protobuf_test.cpp
@@ -1,6 +1,6 @@
-#include "gtest/gtest.h"
-#include "coral/protobuf.hpp"
-#include "testing.pb.h"
+#include <gtest/gtest.h>
+#include <coral/protobuf.hpp>
+#include <testing.pb.h>
 
 
 using namespace coral::protobuf;

--- a/src/lib/protocol_domain.cpp
+++ b/src/lib/protocol_domain.cpp
@@ -4,14 +4,14 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
-#include "coral/protocol/domain.hpp"
+#include <coral/protocol/domain.hpp>
 
 #include <cstring>
 
-#include "coral/error.hpp"
-#include "coral/net/zmqx.hpp"
-#include "coral/protobuf.hpp"
-#include "coral/util.hpp"
+#include <coral/error.hpp>
+#include <coral/net/zmqx.hpp>
+#include <coral/protobuf.hpp>
+#include <coral/util.hpp>
 
 namespace dp = coral::protocol::domain;
 

--- a/src/lib/protocol_exe_data.cpp
+++ b/src/lib/protocol_exe_data.cpp
@@ -4,14 +4,14 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
-#include "coral/protocol/exe_data.hpp"
+#include <coral/protocol/exe_data.hpp>
 
-#include "coral/error.hpp"
-#include "coral/protobuf.hpp"
-#include "coral/protocol/glue.hpp"
-#include "coral/util.hpp"
+#include <coral/error.hpp>
+#include <coral/protobuf.hpp>
+#include <coral/protocol/glue.hpp>
+#include <coral/util.hpp>
 
-#include "exe_data.pb.h"
+#include <exe_data.pb.h>
 
 
 namespace ed = coral::protocol::exe_data;

--- a/src/lib/protocol_exe_data_test.cpp
+++ b/src/lib/protocol_exe_data_test.cpp
@@ -1,5 +1,5 @@
-#include "gtest/gtest.h"
-#include "coral/protocol/exe_data.hpp"
+#include <gtest/gtest.h>
+#include <coral/protocol/exe_data.hpp>
 
 namespace ed = coral::protocol::exe_data;
 

--- a/src/lib/protocol_execution.cpp
+++ b/src/lib/protocol_execution.cpp
@@ -4,16 +4,16 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
-#include "coral/protocol/execution.hpp"
+#include <coral/protocol/execution.hpp>
 
 #include <cassert>
 #include <cstring>
 #include <sstream>
 
-#include "coral/config.h"
-#include "coral/error.hpp"
-#include "coral/protobuf.hpp"
-#include "coral/util.hpp"
+#include <coral/config.h>
+#include <coral/error.hpp>
+#include <coral/protobuf.hpp>
+#include <coral/util.hpp>
 
 
 namespace

--- a/src/lib/protocol_execution_test.cpp
+++ b/src/lib/protocol_execution_test.cpp
@@ -1,9 +1,9 @@
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <cstring>
-#include "coral/protocol/execution.hpp"
-#include "coral/error.hpp"
-#include "coral/protobuf.hpp"
-#include "testing.pb.h"
+#include <coral/protocol/execution.hpp>
+#include <coral/error.hpp>
+#include <coral/protobuf.hpp>
+#include <testing.pb.h>
 
 using namespace coral::protocol::execution;
 

--- a/src/lib/protocol_glue.cpp
+++ b/src/lib/protocol_glue.cpp
@@ -4,7 +4,7 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
-#include "coral/protocol/glue.hpp"
+#include <coral/protocol/glue.hpp>
 
 #include <algorithm>
 #include <cassert>

--- a/src/lib/provider_provider.cpp
+++ b/src/lib/provider_provider.cpp
@@ -4,20 +4,20 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
-#include "coral/provider/provider.hpp"
+#include <coral/provider/provider.hpp>
 
 #include <algorithm>
 #include <cassert>
 
-#include "boost/numeric/conversion/cast.hpp"
-#include "zmq.hpp"
+#include <boost/numeric/conversion/cast.hpp>
+#include <zmq.hpp>
 
-#include "coral/bus/slave_provider_comm.hpp"
-#include "coral/error.hpp"
-#include "coral/net/reactor.hpp"
-#include "coral/net/service.hpp"
-#include "coral/net/zmqx.hpp"
-#include "coral/util.hpp"
+#include <coral/bus/slave_provider_comm.hpp>
+#include <coral/error.hpp>
+#include <coral/net/reactor.hpp>
+#include <coral/net/service.hpp>
+#include <coral/net/zmqx.hpp>
+#include <coral/util.hpp>
 
 
 namespace coral

--- a/src/lib/slave_logging.cpp
+++ b/src/lib/slave_logging.cpp
@@ -4,16 +4,16 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
-#include "coral/slave/logging.hpp"
+#include <coral/slave/logging.hpp>
 
 #include <cassert>
 #include <cerrno>
 #include <ios>
 #include <stdexcept>
 
-#include "coral/error.hpp"
-#include "coral/log.hpp"
-#include "coral/util.hpp"
+#include <coral/error.hpp>
+#include <coral/log.hpp>
+#include <coral/util.hpp>
 
 
 namespace coral

--- a/src/lib/slave_runner.cpp
+++ b/src/lib/slave_runner.cpp
@@ -4,16 +4,16 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
-#include "coral/slave/runner.hpp"
+#include <coral/slave/runner.hpp>
 
 #include <utility>
 #include <vector>
 
-#include "zmq.hpp"
+#include <zmq.hpp>
 
-#include "coral/bus/slave_agent.hpp"
-#include "coral/net/zmqx.hpp"
-#include "coral/util.hpp"
+#include <coral/bus/slave_agent.hpp>
+#include <coral/net/zmqx.hpp>
+#include <coral/util.hpp>
 
 
 namespace coral

--- a/src/lib/util.cpp
+++ b/src/lib/util.cpp
@@ -4,7 +4,7 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
-#include "coral/util.hpp"
+#include <coral/util.hpp>
 
 #ifdef _WIN32
 #   include <Windows.h>
@@ -18,13 +18,13 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #include <ctime>
 #include <iomanip>
 
-#include "boost/filesystem.hpp"
-#include "boost/foreach.hpp"
-#include "boost/numeric/conversion/cast.hpp"
-#include "boost/random/random_device.hpp"
-#include "boost/random/uniform_int_distribution.hpp"
-#include "boost/uuid/random_generator.hpp"
-#include "boost/uuid/uuid_io.hpp"
+#include <boost/filesystem.hpp>
+#include <boost/foreach.hpp>
+#include <boost/numeric/conversion/cast.hpp>
+#include <boost/random/random_device.hpp>
+#include <boost/random/uniform_int_distribution.hpp>
+#include <boost/uuid/random_generator.hpp>
+#include <boost/uuid/uuid_io.hpp>
 
 
 void coral::util::EncodeUint16(std::uint16_t source, char target[2])

--- a/src/lib/util_console.cpp
+++ b/src/lib/util_console.cpp
@@ -4,7 +4,7 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
-#include "coral/util/console.hpp"
+#include <coral/util/console.hpp>
 
 #include <cassert>
 #include <sstream>

--- a/src/lib/util_console_test.cpp
+++ b/src/lib/util_console_test.cpp
@@ -1,6 +1,6 @@
 #include <sstream>
-#include "gtest/gtest.h"
-#include "coral/util/console.hpp"
+#include <gtest/gtest.h>
+#include <coral/util/console.hpp>
 
 
 TEST(coral_util, CommandLine)

--- a/src/lib/util_filesystem.cpp
+++ b/src/lib/util_filesystem.cpp
@@ -4,7 +4,7 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
-#include "coral/util/filesystem.hpp"
+#include <coral/util/filesystem.hpp>
 
 #include <utility>
 #include <boost/filesystem.hpp>

--- a/src/lib/util_test.cpp
+++ b/src/lib/util_test.cpp
@@ -1,5 +1,5 @@
-#include "gtest/gtest.h"
-#include "coral/util.hpp"
+#include <gtest/gtest.h>
+#include <coral/util.hpp>
 #include <functional>
 #include <stdexcept>
 #include <vector>

--- a/src/lib/util_zip.cpp
+++ b/src/lib/util_zip.cpp
@@ -4,7 +4,7 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
-#include "coral/util/zip.hpp"
+#include <coral/util/zip.hpp>
 
 #include <cassert>
 #include <cerrno>
@@ -13,10 +13,10 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #include <system_error>
 #include <vector>
 
-#include "zip.h"
+#include <zip.h>
 
-#include "boost/filesystem.hpp"
-#include "coral/error.hpp"
+#include <boost/filesystem.hpp>
+#include <coral/error.hpp>
 
 
 namespace coral

--- a/src/master/config_parser.cpp
+++ b/src/master/config_parser.cpp
@@ -13,13 +13,13 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #include <utility>
 #include <vector>
 
-#include "boost/foreach.hpp"
-#include "boost/lexical_cast.hpp"
-#include "boost/numeric/conversion/cast.hpp"
-#include "boost/property_tree/info_parser.hpp"
-#include "boost/property_tree/ptree.hpp"
+#include <boost/foreach.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/numeric/conversion/cast.hpp>
+#include <boost/property_tree/info_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
 
-#include "coral/log.hpp"
+#include <coral/log.hpp>
 
 
 SimulationEvent::SimulationEvent(

--- a/src/master/config_parser.hpp
+++ b/src/master/config_parser.hpp
@@ -14,9 +14,9 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #include <string>
 #include <utility>
 #include <vector>
-#include "coral/config.h"
-#include "coral/master.hpp"
-#include "coral/model.hpp"
+#include <coral/config.h>
+#include <coral/master.hpp>
+#include <coral/model.hpp>
 
 
 struct SimulationEvent

--- a/src/master/main.cpp
+++ b/src/master/main.cpp
@@ -15,11 +15,11 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #include <thread>
 #include <vector>
 
-#include "boost/program_options.hpp"
+#include <boost/program_options.hpp>
 
-#include "coral/log.hpp"
-#include "coral/master.hpp"
-#include "coral/util/console.hpp"
+#include <coral/log.hpp>
+#include <coral/master.hpp>
+#include <coral/util/console.hpp>
 
 #include "config_parser.hpp"
 

--- a/src/provider/main.cpp
+++ b/src/provider/main.cpp
@@ -13,19 +13,19 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #include <string>
 #include <vector>
 
-#include "boost/filesystem.hpp"
-#include "boost/lexical_cast.hpp"
+#include <boost/filesystem.hpp>
+#include <boost/lexical_cast.hpp>
 
-#include "zmq.hpp"
+#include <zmq.hpp>
 
-#include "coral/fmi/fmu.hpp"
-#include "coral/fmi/importer.hpp"
-#include "coral/log.hpp"
-#include "coral/net.hpp"
-#include "coral/net/zmqx.hpp"
-#include "coral/provider.hpp"
-#include "coral/util.hpp"
-#include "coral/util/console.hpp"
+#include <coral/fmi/fmu.hpp>
+#include <coral/fmi/importer.hpp>
+#include <coral/log.hpp>
+#include <coral/net.hpp>
+#include <coral/net/zmqx.hpp>
+#include <coral/provider.hpp>
+#include <coral/util.hpp>
+#include <coral/util/console.hpp>
 
 
 namespace

--- a/src/slave/main.cpp
+++ b/src/slave/main.cpp
@@ -14,14 +14,14 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #include <stdexcept>
 #include <string>
 
-#include "boost/filesystem.hpp"
-#include "zmq.hpp"
+#include <boost/filesystem.hpp>
+#include <zmq.hpp>
 
-#include "coral/fmi/fmu.hpp"
-#include "coral/fmi/importer.hpp"
-#include "coral/log.hpp"
-#include "coral/net/zmqx.hpp"
-#include "coral/slave.hpp"
+#include <coral/fmi/fmu.hpp>
+#include <coral/fmi/importer.hpp>
+#include <coral/log.hpp>
+#include <coral/net/zmqx.hpp>
+#include <coral/slave.hpp>
 
 
 /*


### PR DESCRIPTION
Since coral is a library, and the headers are not located together with the sources, virtually all `#include` directives should use angle brackets rather than quotation marks. At best, there is no difference, at worst it could create problems for client code. This fixes them all.