### PR TITLE
Add --no-output switch to slave provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ We don't guarantee that they'll all be documented here, but we'll try to
 list the bigger ones.
 
 ## [Unreleased]
+### Added
+  - A `--no-output` switch in coralslaveprovider, which disables file
+    output of variable values.
 
 ## [0.8.0] – 2017-04-07
 ### Added


### PR DESCRIPTION
Some people have complained that their simulations are significantly slowed down by file I/O. This adds an option to disable file output entirely.