### PR TITLE
Use std::fixed to format time column in CSV files

### DIFF
--- a/src/lib/slave_logging.cpp
+++ b/src/lib/slave_logging.cpp
@@ -136,7 +136,7 @@ bool LoggingInstance::DoStep(
 {
     const auto ret = m_instance->DoStep(currentT, deltaT);
 
-    m_outputStream << (currentT + deltaT);
+    m_outputStream << std::fixed << (currentT + deltaT) << std::defaultfloat;
     const auto typeDescription = TypeDescription();
     for (const auto& var : typeDescription.Variables()) {
         PrintVariable(m_outputStream, var, *this);


### PR DESCRIPTION
The default precision for an output stream is 6 digits, and with the `std::fixed` format this is interpreted to mean maximum number of digits *after the decimal point*. Assuming time is in units of seconds, this means it is now printed with microsecond precision.

This fixes issue #54, "Too low time precision in CSV output".